### PR TITLE
ci: pin runner OS versions to specific releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   backend:
     name: Backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -46,7 +46,7 @@ jobs:
 
   frontend:
     name: Frontend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-15]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   tagpr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
       tag: ${{ steps.tagpr.outputs.tag }}
@@ -35,7 +35,7 @@ jobs:
   release:
     needs: tagpr
     if: needs.tagpr.outputs.tag != ''
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   scan:
     name: Filesystem scan (vuln + license)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `ubuntu-latest` → `ubuntu-24.04`
- `macos-latest` → `macos-15`
- 対象: `ci.yml`, `tagpr.yml`, `trivy.yml`

`latest` エイリアスは GitHub 側のタイミングでバージョンが上がるため、意図しない破壊的変更を避けるために固定バージョンへ切り替えました。

## Test plan

- [ ] CI (backend / frontend / e2e) が `ubuntu-24.04` / `macos-15` で正常に通ることを確認

https://claude.ai/code/session_016z4KmpPWt9eGMBZRxV8NsC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016z4KmpPWt9eGMBZRxV8NsC)_