### PR TITLE
feat(preview): raise max zoom from 1000% to 5000%

### DIFF
--- a/frontend/src/components/Preview.tsx
+++ b/frontend/src/components/Preview.tsx
@@ -7,7 +7,7 @@ import {
 import type { JSX } from "react";
 
 const MIN_SCALE = 0.1;
-const MAX_SCALE = 10;
+const MAX_SCALE = 50;
 
 const BASE_BTN =
   "flex h-8 cursor-pointer items-center rounded border border-slate-200 bg-white/90 text-slate-600 shadow-sm backdrop-blur-sm hover:bg-white active:bg-slate-100";


### PR DESCRIPTION
## Summary

非常に大きな図では 1000% でも文字が潰れて読めないことがあるため、Preview の `maxScale` を 10 → 50（1000% → 5000%）に引き上げ。

`MIN_SCALE` (0.1) は変更なし。ホイール／ピンチ／ボタンいずれもライブラリ側の挙動に依存し、新しい上限まで連続的に拡大できる。

## Test plan

- [x] `pnpm test` — 50/50 通過（zoom レベル表示テスト含む）
- [x] 実機（Chromium）で `examples/large-er.puml` を開き、ズームインボタン・マウスホイールいずれでも 5000% まで到達することを確認
- [x] 5000% 状態でリセットボタンが 100% に戻ること、その後再度拡大できることを確認
- [x] 最大ズーム時にドラッグでパン操作が引き続き動作することを確認
- [x] ズームレベル表示（`w-14`）に "5000%" が崩れずに収まることを目視確認