### PR TITLE
docs: add mise GitHub backend installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,10 @@ Download a pre-built binary from the [releases page](https://github.com/rin2yh/p
 go install github.com/rin2yh/pumlv@latest
 ```
 
-### Using mise (GitHub backend)
-
-[mise](https://mise.jdx.dev/) can install pumlv directly from GitHub releases via its [GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html):
+Or with [mise](https://mise.jdx.dev/) ([GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html)):
 
 ```sh
-mise use -g github:rin2yh/pumlv         # latest release
-mise use -g github:rin2yh/pumlv@0.1.0   # pin a specific version
-```
-
-Or declare it in your project's `mise.toml`:
-
-```toml
-[tools]
-"github:rin2yh/pumlv" = "latest"
+mise use -g github:rin2yh/pumlv
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ Download a pre-built binary from the [releases page](https://github.com/rin2yh/p
 go install github.com/rin2yh/pumlv@latest
 ```
 
+### Using mise (GitHub backend)
+
+[mise](https://mise.jdx.dev/) can install pumlv directly from GitHub releases via its [GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html):
+
+```sh
+mise use -g github:rin2yh/pumlv         # latest release
+mise use -g github:rin2yh/pumlv@0.1.0   # pin a specific version
+```
+
+Or declare it in your project's `mise.toml`:
+
+```toml
+[tools]
+"github:rin2yh/pumlv" = "latest"
+```
+
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Add a new "Using mise (GitHub backend)" subsection under Installation in `README.md`, showing how to install pumlv from GitHub releases via [mise](https://mise.jdx.dev/)'s [GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html).
- Covers both ad-hoc CLI usage (`mise use -g github:rin2yh/pumlv[@version]`) and declarative project config in `mise.toml`.

The goreleaser pipeline already publishes archives in the format mise's GitHub backend expects (`pumlv_v{version}_{os}_{arch}.{tar.gz|zip}` containing a `pumlv` binary), so no release pipeline changes are required.

## Test plan

- [x] Verified rendered Markdown by inspecting the diff — code fences and links are well-formed.
- [ ] Docs-only change: no code paths touched, so `make test` / `make lint` / `make e2e` are not exercised by this PR.

https://claude.ai/code/session_01CVfDyKVjPw51MLWsw7agjL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVfDyKVjPw51MLWsw7agjL)_