### PR TITLE
feat(preview): make zoom level numeric display editable

### DIFF
--- a/frontend/src/components/preview.test.tsx
+++ b/frontend/src/components/preview.test.tsx
@@ -6,6 +6,7 @@ import { setupRender } from "../test/render";
 const mockZoomIn = vi.fn();
 const mockZoomOut = vi.fn();
 const mockResetTransform = vi.fn();
+const mockCenterView = vi.fn();
 
 let mockScale = 1;
 
@@ -16,6 +17,7 @@ vi.mock("react-zoom-pan-pinch", () => ({
     zoomIn: mockZoomIn,
     zoomOut: mockZoomOut,
     resetTransform: mockResetTransform,
+    centerView: mockCenterView,
   }),
   useTransformComponent: (cb: (s: { state: { scale: number } }) => unknown) =>
     cb({ state: { scale: mockScale } }),
@@ -23,7 +25,23 @@ vi.mock("react-zoom-pan-pinch", () => ({
 
 const SAMPLE_SVG = "data:image/png;base64,AAAA";
 
-const zoomLevel = () => document.querySelector('[aria-label="Zoom level"]')!.textContent;
+const zoomInput = () => document.querySelector<HTMLInputElement>('input[aria-label="Zoom level"]')!;
+const zoomLevel = () => zoomInput().value;
+
+const typeAndCommit = (value: string, { key = "Enter" } = {}) => {
+  const input = zoomInput();
+  act(() => {
+    input.focus();
+  });
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  act(() => {
+    input.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+};
 
 const render = setupRender();
 
@@ -76,23 +94,78 @@ describe("Preview", () => {
     });
 
     it.each([
-      { scale: 1, expected: "100%" },
-      { scale: 0.5, expected: "50%" },
-      { scale: 2.5, expected: "250%" },
-    ])("displays zoom level as $expected when scale is $scale", ({ scale, expected }) => {
+      { scale: 1, expected: "100" },
+      { scale: 0.5, expected: "50" },
+      { scale: 2.5, expected: "250" },
+    ])("displays zoom level as $expected% when scale is $scale", ({ scale, expected }) => {
       mockScale = scale;
       render(<Preview svg={SAMPLE_SVG} />);
-      expect(document.querySelector('[aria-label="Zoom level"]')!.textContent).toBe(expected);
+      expect(zoomInput().value).toBe(expected);
     });
 
-    it("resets zoom display to 100% when svg prop changes", () => {
+    it("resets zoom display to 100 when svg prop changes", () => {
       mockScale = 2;
       render(<Preview svg={SAMPLE_SVG} />);
-      expect(zoomLevel()).toBe("200%");
+      expect(zoomLevel()).toBe("200");
 
       mockScale = 1;
       render(<Preview svg="data:image/png;base64,BBBB" />);
-      expect(zoomLevel()).toBe("100%");
+      expect(zoomLevel()).toBe("100");
+    });
+
+    it.each([
+      { input: "150", expectedScale: 1.5 },
+      { input: "75", expectedScale: 0.75 },
+      { input: "200%", expectedScale: 2 },
+    ])(
+      "typing '$input' and pressing Enter calls centerView with scale=$expectedScale",
+      ({ input, expectedScale }) => {
+        render(<Preview svg={SAMPLE_SVG} />);
+        typeAndCommit(input);
+        expect(mockCenterView).toHaveBeenCalledWith(expectedScale, 0);
+      },
+    );
+
+    it.each([
+      { input: "5", expectedScale: 0.1 },
+      { input: "10000", expectedScale: 50 },
+    ])("clamps '$input%' to scale=$expectedScale (MIN/MAX bounds)", ({ input, expectedScale }) => {
+      render(<Preview svg={SAMPLE_SVG} />);
+      typeAndCommit(input);
+      expect(mockCenterView).toHaveBeenCalledWith(expectedScale, 0);
+    });
+
+    it.each(["abc", "", "-50", "0"])(
+      "ignores invalid input '%s' without calling centerView",
+      (value) => {
+        render(<Preview svg={SAMPLE_SVG} />);
+        typeAndCommit(value);
+        expect(mockCenterView).not.toHaveBeenCalled();
+      },
+    );
+
+    it("pressing Escape reverts the draft and does not call centerView", () => {
+      mockScale = 1;
+      render(<Preview svg={SAMPLE_SVG} />);
+      typeAndCommit("250", { key: "Escape" });
+      expect(mockCenterView).not.toHaveBeenCalled();
+      expect(zoomInput().value).toBe("100");
+    });
+
+    it("blurring the input without changing it does not call centerView with a NaN", () => {
+      render(<Preview svg={SAMPLE_SVG} />);
+      const input = zoomInput();
+      act(() => {
+        input.focus();
+      });
+      act(() => {
+        input.blur();
+      });
+      // value '100' is valid — but it's the current scale, so centerView is called with 1.
+      // Either it isn't called, or it's called with the same scale; both are fine. NaN must not occur.
+      if (mockCenterView.mock.calls.length > 0) {
+        expect(mockCenterView).toHaveBeenCalledWith(1, 0);
+      }
     });
   });
 });

--- a/frontend/src/components/preview.test.tsx
+++ b/frontend/src/components/preview.test.tsx
@@ -117,23 +117,16 @@ describe("Preview", () => {
       { input: "150", expectedScale: 1.5 },
       { input: "75", expectedScale: 0.75 },
       { input: "200%", expectedScale: 2 },
+      { input: "5", expectedScale: 0.1 },
+      { input: "10000", expectedScale: 50 },
     ])(
-      "typing '$input' and pressing Enter calls centerView with scale=$expectedScale",
+      "typing '$input' commits scale=$expectedScale via centerView (clamped to MIN/MAX)",
       ({ input, expectedScale }) => {
         render(<Preview svg={SAMPLE_SVG} />);
         typeAndCommit(input);
         expect(mockCenterView).toHaveBeenCalledWith(expectedScale, 0);
       },
     );
-
-    it.each([
-      { input: "5", expectedScale: 0.1 },
-      { input: "10000", expectedScale: 50 },
-    ])("clamps '$input%' to scale=$expectedScale (MIN/MAX bounds)", ({ input, expectedScale }) => {
-      render(<Preview svg={SAMPLE_SVG} />);
-      typeAndCommit(input);
-      expect(mockCenterView).toHaveBeenCalledWith(expectedScale, 0);
-    });
 
     it.each(["abc", "", "-50", "0"])(
       "ignores invalid input '%s' without calling centerView",
@@ -152,7 +145,8 @@ describe("Preview", () => {
       expect(zoomInput().value).toBe("100");
     });
 
-    it("blurring the input without changing it does not call centerView with a NaN", () => {
+    it("focusing then blurring without typing commits the current scale", () => {
+      mockScale = 1;
       render(<Preview svg={SAMPLE_SVG} />);
       const input = zoomInput();
       act(() => {
@@ -161,11 +155,7 @@ describe("Preview", () => {
       act(() => {
         input.blur();
       });
-      // value '100' is valid — but it's the current scale, so centerView is called with 1.
-      // Either it isn't called, or it's called with the same scale; both are fine. NaN must not occur.
-      if (mockCenterView.mock.calls.length > 0) {
-        expect(mockCenterView).toHaveBeenCalledWith(1, 0);
-      }
+      expect(mockCenterView).toHaveBeenCalledWith(1, 0);
     });
   });
 });

--- a/frontend/src/components/preview.tsx
+++ b/frontend/src/components/preview.tsx
@@ -4,7 +4,7 @@ import {
   useControls,
   useTransformComponent,
 } from "react-zoom-pan-pinch";
-import { useEffect, useRef, useState, type FocusEvent, type JSX, type KeyboardEvent } from "react";
+import { useRef, useState, type FocusEvent, type JSX, type KeyboardEvent } from "react";
 
 const MIN_SCALE = 0.1;
 const MAX_SCALE = 50;
@@ -25,33 +25,29 @@ function ZoomControls(): JSX.Element {
   const scale = useTransformComponent(({ state }) => state.scale);
   const displayPercent = Math.round(scale * 100);
 
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(String(displayPercent));
+  // null = not editing; the input mirrors displayPercent. A string value
+  // means the user is mid-edit and that draft takes over until commit/cancel.
+  const [draft, setDraft] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const skipCommitRef = useRef(false);
-
-  // Sync the input with the live scale whenever the user isn't editing.
-  useEffect(() => {
-    if (!editing) setDraft(String(displayPercent));
-  }, [displayPercent, editing]);
 
   const commit = () => {
     if (skipCommitRef.current) {
       skipCommitRef.current = false;
-      setEditing(false);
+      setDraft(null);
       return;
     }
+    if (draft === null) return;
     const parsed = Number.parseFloat(draft);
     if (Number.isFinite(parsed) && parsed > 0) {
       centerView(clampScale(parsed / 100), 0);
     }
-    setEditing(false);
+    setDraft(null);
   };
 
   const cancel = () => {
     skipCommitRef.current = true;
-    setDraft(String(displayPercent));
-    setEditing(false);
+    setDraft(null);
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -67,7 +63,6 @@ function ZoomControls(): JSX.Element {
   };
 
   const onFocus = (e: FocusEvent<HTMLInputElement>) => {
-    setEditing(true);
     setDraft(String(displayPercent));
     e.target.select();
   };
@@ -87,7 +82,7 @@ function ZoomControls(): JSX.Element {
           ref={inputRef}
           type="text"
           inputMode="numeric"
-          value={editing ? draft : String(displayPercent)}
+          value={draft ?? String(displayPercent)}
           onChange={(e) => setDraft(e.target.value)}
           onFocus={onFocus}
           onBlur={commit}

--- a/frontend/src/components/preview.tsx
+++ b/frontend/src/components/preview.tsx
@@ -4,7 +4,7 @@ import {
   useControls,
   useTransformComponent,
 } from "react-zoom-pan-pinch";
-import type { JSX } from "react";
+import { useEffect, useRef, useState, type FocusEvent, type JSX, type KeyboardEvent } from "react";
 
 const MIN_SCALE = 0.1;
 const MAX_SCALE = 50;
@@ -12,11 +12,65 @@ const MAX_SCALE = 50;
 const BASE_BTN =
   "flex h-8 cursor-pointer items-center rounded border border-slate-200 bg-white/90 text-slate-600 shadow-sm backdrop-blur-sm hover:bg-white active:bg-slate-100";
 
+function clampScale(value: number): number {
+  if (value < MIN_SCALE) return MIN_SCALE;
+  if (value > MAX_SCALE) return MAX_SCALE;
+  return value;
+}
+
 function ZoomControls(): JSX.Element {
-  const { zoomIn, zoomOut, resetTransform } = useControls();
+  const { zoomIn, zoomOut, resetTransform, centerView } = useControls();
   // useTransformComponent re-renders on every transform change (wheel/pinch
   // included), unlike useTransformContext which only exposes a ref.
   const scale = useTransformComponent(({ state }) => state.scale);
+  const displayPercent = Math.round(scale * 100);
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(displayPercent));
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const skipCommitRef = useRef(false);
+
+  // Sync the input with the live scale whenever the user isn't editing.
+  useEffect(() => {
+    if (!editing) setDraft(String(displayPercent));
+  }, [displayPercent, editing]);
+
+  const commit = () => {
+    if (skipCommitRef.current) {
+      skipCommitRef.current = false;
+      setEditing(false);
+      return;
+    }
+    const parsed = Number.parseFloat(draft);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      centerView(clampScale(parsed / 100), 0);
+    }
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    skipCommitRef.current = true;
+    setDraft(String(displayPercent));
+    setEditing(false);
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit();
+      inputRef.current?.blur();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      cancel();
+      inputRef.current?.blur();
+    }
+  };
+
+  const onFocus = (e: FocusEvent<HTMLInputElement>) => {
+    setEditing(true);
+    setDraft(String(displayPercent));
+    e.target.select();
+  };
 
   return (
     <div className="absolute bottom-3 right-3 z-20 flex gap-1">
@@ -28,12 +82,21 @@ function ZoomControls(): JSX.Element {
       >
         −
       </button>
-      <span
-        className="flex h-8 w-14 items-center justify-center rounded border border-slate-200 bg-white/90 text-xs tabular-nums text-slate-600 shadow-sm backdrop-blur-sm"
-        aria-label="Zoom level"
-      >
-        {Math.round(scale * 100)}%
-      </span>
+      <div className="flex h-8 w-14 items-center justify-center rounded border border-slate-200 bg-white/90 text-xs tabular-nums text-slate-600 shadow-sm backdrop-blur-sm focus-within:ring-1 focus-within:ring-slate-400">
+        <input
+          ref={inputRef}
+          type="text"
+          inputMode="numeric"
+          value={editing ? draft : String(displayPercent)}
+          onChange={(e) => setDraft(e.target.value)}
+          onFocus={onFocus}
+          onBlur={commit}
+          onKeyDown={onKeyDown}
+          className="h-full w-8 cursor-text bg-transparent text-right outline-none"
+          aria-label="Zoom level"
+        />
+        <span aria-hidden="true">%</span>
+      </div>
       <button
         type="button"
         onClick={() => zoomIn()}

--- a/frontend/src/components/preview.tsx
+++ b/frontend/src/components/preview.tsx
@@ -53,7 +53,7 @@ function ZoomControls(): JSX.Element {
     setDraft(null);
   };
 
-  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
       commit();
@@ -65,7 +65,7 @@ function ZoomControls(): JSX.Element {
     }
   };
 
-  const onFocus = (e: FocusEvent<HTMLInputElement>) => {
+  const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
     setDraft(String(displayPercent));
     e.target.select();
   };
@@ -87,9 +87,9 @@ function ZoomControls(): JSX.Element {
           inputMode="numeric"
           value={draft ?? String(displayPercent)}
           onChange={(e) => setDraft(e.target.value)}
-          onFocus={onFocus}
+          onFocus={handleFocus}
           onBlur={commit}
-          onKeyDown={onKeyDown}
+          onKeyDown={handleKeyDown}
           className="h-full w-8 cursor-text bg-transparent text-right outline-none"
           aria-label="Zoom level"
         />

--- a/frontend/tests/e2e/zoom.spec.ts
+++ b/frontend/tests/e2e/zoom.spec.ts
@@ -1,14 +1,14 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("Zoom controls", () => {
-  test("typing a percentage into the zoom input zooms to that scale", async ({ page }) => {
-    const preview = page.getByAltText("preview");
-    const zoomInput = page.getByLabel("Zoom level");
-
+  test.beforeEach(async ({ page }) => {
     await page.goto("/");
-    await expect(preview).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByAltText("preview")).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByLabel("Zoom level")).toHaveValue("100");
+  });
 
-    await expect(zoomInput).toHaveValue("100");
+  test("typing a percentage into the zoom input zooms to that scale", async ({ page }) => {
+    const zoomInput = page.getByLabel("Zoom level");
 
     await zoomInput.focus();
     await page.keyboard.press("ControlOrMeta+A");
@@ -19,12 +19,7 @@ test.describe("Zoom controls", () => {
   });
 
   test("Escape reverts the draft without changing zoom", async ({ page }) => {
-    const preview = page.getByAltText("preview");
     const zoomInput = page.getByLabel("Zoom level");
-
-    await page.goto("/");
-    await expect(preview).toBeVisible({ timeout: 60_000 });
-    await expect(zoomInput).toHaveValue("100");
 
     await zoomInput.focus();
     await page.keyboard.press("ControlOrMeta+A");
@@ -35,11 +30,7 @@ test.describe("Zoom controls", () => {
   });
 
   test("invalid input is ignored and display stays at the current scale", async ({ page }) => {
-    const preview = page.getByAltText("preview");
     const zoomInput = page.getByLabel("Zoom level");
-
-    await page.goto("/");
-    await expect(preview).toBeVisible({ timeout: 60_000 });
 
     await zoomInput.focus();
     await page.keyboard.press("ControlOrMeta+A");

--- a/frontend/tests/e2e/zoom.spec.ts
+++ b/frontend/tests/e2e/zoom.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Zoom controls", () => {
+  test("typing a percentage into the zoom input zooms to that scale", async ({ page }) => {
+    const preview = page.getByAltText("preview");
+    const zoomInput = page.getByLabel("Zoom level");
+
+    await page.goto("/");
+    await expect(preview).toBeVisible({ timeout: 60_000 });
+
+    await expect(zoomInput).toHaveValue("100");
+
+    await zoomInput.focus();
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.type("200");
+    await page.keyboard.press("Enter");
+
+    await expect(zoomInput).toHaveValue("200");
+  });
+
+  test("Escape reverts the draft without changing zoom", async ({ page }) => {
+    const preview = page.getByAltText("preview");
+    const zoomInput = page.getByLabel("Zoom level");
+
+    await page.goto("/");
+    await expect(preview).toBeVisible({ timeout: 60_000 });
+    await expect(zoomInput).toHaveValue("100");
+
+    await zoomInput.focus();
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.type("400");
+    await page.keyboard.press("Escape");
+
+    await expect(zoomInput).toHaveValue("100");
+  });
+
+  test("invalid input is ignored and display stays at the current scale", async ({ page }) => {
+    const preview = page.getByAltText("preview");
+    const zoomInput = page.getByLabel("Zoom level");
+
+    await page.goto("/");
+    await expect(preview).toBeVisible({ timeout: 60_000 });
+
+    await zoomInput.focus();
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.type("abc");
+    await page.keyboard.press("Enter");
+
+    await expect(zoomInput).toHaveValue("100");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the static `<span>` zoom-level readout in the preview pane with an `<input>`, so the user can type a percentage and zoom directly to that value
- Enter (or blur) commits via `centerView(scale, 0)`; Escape reverts the draft; input is clamped to `MIN_SCALE`–`MAX_SCALE` and non-numeric values are ignored
- The input keeps tracking live scale (wheel / pinch / +/− buttons) whenever the user isn't editing it
- State is a single `draft: string | null` (null = mirror live scale, string = mid-edit)

## Test plan
- [x] `make test-frontend` — 79 unit tests pass, including new coverage for typing/clamping/Escape/invalid-input paths in `preview.test.tsx`
- [x] `make lint` — frontend (oxlint + oxfmt) and backend (`go vet`, `go fmt`) clean
- [x] `make test-backend` — `server` package passes (Makefile target also surfaced `go: no such tool "covdata"`, a Go toolchain glitch in the sandbox unrelated to this change; `go test ./...` without race+coverage is green)
- [x] `make e2e` — verified manually by driving the real `pumlv` binary with bundled Playwright Chromium (the project's `channel: "chrome"` can't install in this sandbox). All 7 scenarios pass: initial 100% → type 200+Enter → 200%; type 400+Escape → reverts to 200%; invalid `abc` → unchanged; `50000` → clamped to MAX (5000%); `1` → clamped to MIN (10%); Reset button → 100%. The committed spec is `frontend/tests/e2e/zoom.spec.ts`; CI will exercise it.

https://claude.ai/code/session_01UdozjriQs9HejYtBf2D9F6