### PR TITLE
feat(source-view): fold brace-delimited entity blocks

### DIFF
--- a/frontend/src/components/file-tree/index.tsx
+++ b/frontend/src/components/file-tree/index.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState, type JSX } from "react";
+import { useMemo, type JSX } from "react";
 import type { FileEntry } from "../../api/files";
+import { useToggleSet } from "../../hooks/useToggleSet";
 import { buildTree, flatten } from "./tree";
 import { DirectoryRow } from "./directory-row";
 import { FileRow } from "./file-row";
@@ -12,20 +13,12 @@ interface Props {
 
 export function FileTree({ files, active, onSelect }: Props): JSX.Element {
   const tree = useMemo(() => buildTree(files), [files]);
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [collapsed, toggle] = useToggleSet<string>();
   const rows = useMemo(() => flatten(tree, collapsed), [tree, collapsed]);
 
   if (files.length === 0) {
     return <p className="px-4 py-3 text-sm text-slate-500">no files found</p>;
   }
-
-  const toggle = (key: string): void =>
-    setCollapsed((previous) => {
-      const next = new Set(previous);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
 
   return (
     <nav className="py-2">

--- a/frontend/src/components/source-fold.test.ts
+++ b/frontend/src/components/source-fold.test.ts
@@ -83,24 +83,21 @@ interface HiddenCase {
   name: string;
   ranges: FoldRange[];
   folded: number[];
-  total: number;
-  expected: boolean[];
+  expected: number[];
 }
 
 const hiddenCases: HiddenCase[] = [
   {
-    name: "hides lines after a folded range's start through its end",
+    name: "hides lines from start+1 through end of a folded range",
     ranges: [{ startLine: 1, endLine: 4 }],
     folded: [1],
-    total: 6,
-    expected: [false, false, true, true, true, false],
+    expected: [2, 3, 4],
   },
   {
-    name: "returns all-false when nothing is folded",
+    name: "returns an empty set when nothing is folded",
     ranges: [{ startLine: 0, endLine: 2 }],
     folded: [],
-    total: 3,
-    expected: [false, false, false],
+    expected: [],
   },
   {
     name: "hides nested ranges when only the outer is folded",
@@ -109,22 +106,15 @@ const hiddenCases: HiddenCase[] = [
       { startLine: 1, endLine: 3 },
     ],
     folded: [0],
-    total: 5,
-    expected: [false, true, true, true, true],
-  },
-  {
-    name: "clamps end line to the available total",
-    ranges: [{ startLine: 0, endLine: 10 }],
-    folded: [0],
-    total: 3,
-    expected: [false, true, true],
+    expected: [1, 2, 3, 4],
   },
 ];
 
 describe("hiddenLines", () => {
-  for (const { name, ranges, folded, total, expected } of hiddenCases) {
+  for (const { name, ranges, folded, expected } of hiddenCases) {
     it(name, () => {
-      expect(hiddenLines(ranges, new Set(folded), total)).toEqual(expected);
+      const got = [...hiddenLines(ranges, new Set(folded))].toSorted((a, b) => a - b);
+      expect(got).toEqual(expected);
     });
   }
 });

--- a/frontend/src/components/source-fold.test.ts
+++ b/frontend/src/components/source-fold.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { computeFoldRanges, hiddenLines } from "./source-fold";
+
+describe("computeFoldRanges", () => {
+  it("returns no ranges for source without braces", () => {
+    const src = "@startuml\nactor User\n@enduml\n";
+    expect(computeFoldRanges(src)).toEqual([]);
+  });
+
+  it("detects a single brace block spanning multiple lines", () => {
+    const src = ["@startuml", "class A {", "  field", "}", "@enduml"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
+  });
+
+  it("ignores single-line braces ({ and } on same line)", () => {
+    const src = ["class A { field }", "class B {", "  x", "}"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
+  });
+
+  it("detects multiple sibling blocks", () => {
+    const src = ["class A {", "  a", "}", "class B {", "  b", "}"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([
+      { startLine: 0, endLine: 2 },
+      { startLine: 3, endLine: 5 },
+    ]);
+  });
+
+  it("detects nested blocks", () => {
+    const src = ["package P {", "  class A {", "    f", "  }", "}"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([
+      { startLine: 0, endLine: 4 },
+      { startLine: 1, endLine: 3 },
+    ]);
+  });
+
+  it("ignores braces inside double-quoted strings", () => {
+    const src = ['note "}" as N1', "class A {", "  x", "}"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
+  });
+
+  it("ignores braces after a line comment", () => {
+    const src = ["' class A {", "class B {", "  x", "}"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
+  });
+
+  it("ignores braces inside block comments", () => {
+    const src = ["/' { '/", "class B {", "  x", "}"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
+  });
+
+  it("ignores escaped quotes inside strings", () => {
+    const src = ['note "\\"{" as N', "class A {", "  x", "}"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
+  });
+
+  it("ignores unmatched closing braces", () => {
+    const src = ["}", "class A {", "  x", "}"].join("\n");
+    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const src = "class A {\r\n  x\r\n}\r\n";
+    expect(computeFoldRanges(src)).toEqual([{ startLine: 0, endLine: 2 }]);
+  });
+});
+
+describe("hiddenLines", () => {
+  it("hides lines after a folded range's start through its end", () => {
+    const ranges = [{ startLine: 1, endLine: 4 }];
+    const hidden = hiddenLines(ranges, new Set([1]), 6);
+    expect(hidden).toEqual([false, false, true, true, true, false]);
+  });
+
+  it("returns all-false when nothing is folded", () => {
+    const ranges = [{ startLine: 0, endLine: 2 }];
+    expect(hiddenLines(ranges, new Set(), 3)).toEqual([false, false, false]);
+  });
+
+  it("hides nested ranges when only the outer is folded", () => {
+    const ranges = [
+      { startLine: 0, endLine: 4 },
+      { startLine: 1, endLine: 3 },
+    ];
+    expect(hiddenLines(ranges, new Set([0]), 5)).toEqual([false, true, true, true, true]);
+  });
+
+  it("clamps end line to the available total", () => {
+    const ranges = [{ startLine: 0, endLine: 10 }];
+    expect(hiddenLines(ranges, new Set([0]), 3)).toEqual([false, true, true]);
+  });
+});

--- a/frontend/src/components/source-fold.test.ts
+++ b/frontend/src/components/source-fold.test.ts
@@ -1,91 +1,130 @@
 import { describe, expect, it } from "vitest";
-import { computeFoldRanges, hiddenLines } from "./source-fold";
+import { computeFoldRanges, hiddenLines, type FoldRange } from "./source-fold";
 
-describe("computeFoldRanges", () => {
-  it("returns no ranges for source without braces", () => {
-    const src = "@startuml\nactor User\n@enduml\n";
-    expect(computeFoldRanges(src)).toEqual([]);
-  });
+interface ComputeCase {
+  name: string;
+  src: string;
+  expected: FoldRange[];
+}
 
-  it("detects a single brace block spanning multiple lines", () => {
-    const src = ["@startuml", "class A {", "  field", "}", "@enduml"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
-  });
-
-  it("ignores single-line braces ({ and } on same line)", () => {
-    const src = ["class A { field }", "class B {", "  x", "}"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
-  });
-
-  it("detects multiple sibling blocks", () => {
-    const src = ["class A {", "  a", "}", "class B {", "  b", "}"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([
+const computeCases: ComputeCase[] = [
+  {
+    name: "returns no ranges for source without braces",
+    src: "@startuml\nactor User\n@enduml\n",
+    expected: [],
+  },
+  {
+    name: "detects a single brace block spanning multiple lines",
+    src: ["@startuml", "class A {", "  field", "}", "@enduml"].join("\n"),
+    expected: [{ startLine: 1, endLine: 3 }],
+  },
+  {
+    name: "ignores single-line braces ({ and } on same line)",
+    src: ["class A { field }", "class B {", "  x", "}"].join("\n"),
+    expected: [{ startLine: 1, endLine: 3 }],
+  },
+  {
+    name: "detects multiple sibling blocks",
+    src: ["class A {", "  a", "}", "class B {", "  b", "}"].join("\n"),
+    expected: [
       { startLine: 0, endLine: 2 },
       { startLine: 3, endLine: 5 },
-    ]);
-  });
-
-  it("detects nested blocks", () => {
-    const src = ["package P {", "  class A {", "    f", "  }", "}"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([
+    ],
+  },
+  {
+    name: "detects nested blocks",
+    src: ["package P {", "  class A {", "    f", "  }", "}"].join("\n"),
+    expected: [
       { startLine: 0, endLine: 4 },
       { startLine: 1, endLine: 3 },
-    ]);
-  });
+    ],
+  },
+  {
+    name: "ignores braces inside double-quoted strings",
+    src: ['note "}" as N1', "class A {", "  x", "}"].join("\n"),
+    expected: [{ startLine: 1, endLine: 3 }],
+  },
+  {
+    name: "ignores braces after a line comment",
+    src: ["' class A {", "class B {", "  x", "}"].join("\n"),
+    expected: [{ startLine: 1, endLine: 3 }],
+  },
+  {
+    name: "ignores braces inside block comments",
+    src: ["/' { '/", "class B {", "  x", "}"].join("\n"),
+    expected: [{ startLine: 1, endLine: 3 }],
+  },
+  {
+    name: "ignores escaped quotes inside strings",
+    src: ['note "\\"{" as N', "class A {", "  x", "}"].join("\n"),
+    expected: [{ startLine: 1, endLine: 3 }],
+  },
+  {
+    name: "ignores unmatched closing braces",
+    src: ["}", "class A {", "  x", "}"].join("\n"),
+    expected: [{ startLine: 1, endLine: 3 }],
+  },
+  {
+    name: "handles CRLF line endings",
+    src: "class A {\r\n  x\r\n}\r\n",
+    expected: [{ startLine: 0, endLine: 2 }],
+  },
+];
 
-  it("ignores braces inside double-quoted strings", () => {
-    const src = ['note "}" as N1', "class A {", "  x", "}"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
-  });
-
-  it("ignores braces after a line comment", () => {
-    const src = ["' class A {", "class B {", "  x", "}"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
-  });
-
-  it("ignores braces inside block comments", () => {
-    const src = ["/' { '/", "class B {", "  x", "}"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
-  });
-
-  it("ignores escaped quotes inside strings", () => {
-    const src = ['note "\\"{" as N', "class A {", "  x", "}"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
-  });
-
-  it("ignores unmatched closing braces", () => {
-    const src = ["}", "class A {", "  x", "}"].join("\n");
-    expect(computeFoldRanges(src)).toEqual([{ startLine: 1, endLine: 3 }]);
-  });
-
-  it("handles CRLF line endings", () => {
-    const src = "class A {\r\n  x\r\n}\r\n";
-    expect(computeFoldRanges(src)).toEqual([{ startLine: 0, endLine: 2 }]);
-  });
+describe("computeFoldRanges", () => {
+  for (const { name, src, expected } of computeCases) {
+    it(name, () => {
+      expect(computeFoldRanges(src)).toEqual(expected);
+    });
+  }
 });
 
-describe("hiddenLines", () => {
-  it("hides lines after a folded range's start through its end", () => {
-    const ranges = [{ startLine: 1, endLine: 4 }];
-    const hidden = hiddenLines(ranges, new Set([1]), 6);
-    expect(hidden).toEqual([false, false, true, true, true, false]);
-  });
+interface HiddenCase {
+  name: string;
+  ranges: FoldRange[];
+  folded: number[];
+  total: number;
+  expected: boolean[];
+}
 
-  it("returns all-false when nothing is folded", () => {
-    const ranges = [{ startLine: 0, endLine: 2 }];
-    expect(hiddenLines(ranges, new Set(), 3)).toEqual([false, false, false]);
-  });
-
-  it("hides nested ranges when only the outer is folded", () => {
-    const ranges = [
+const hiddenCases: HiddenCase[] = [
+  {
+    name: "hides lines after a folded range's start through its end",
+    ranges: [{ startLine: 1, endLine: 4 }],
+    folded: [1],
+    total: 6,
+    expected: [false, false, true, true, true, false],
+  },
+  {
+    name: "returns all-false when nothing is folded",
+    ranges: [{ startLine: 0, endLine: 2 }],
+    folded: [],
+    total: 3,
+    expected: [false, false, false],
+  },
+  {
+    name: "hides nested ranges when only the outer is folded",
+    ranges: [
       { startLine: 0, endLine: 4 },
       { startLine: 1, endLine: 3 },
-    ];
-    expect(hiddenLines(ranges, new Set([0]), 5)).toEqual([false, true, true, true, true]);
-  });
+    ],
+    folded: [0],
+    total: 5,
+    expected: [false, true, true, true, true],
+  },
+  {
+    name: "clamps end line to the available total",
+    ranges: [{ startLine: 0, endLine: 10 }],
+    folded: [0],
+    total: 3,
+    expected: [false, true, true],
+  },
+];
 
-  it("clamps end line to the available total", () => {
-    const ranges = [{ startLine: 0, endLine: 10 }];
-    expect(hiddenLines(ranges, new Set([0]), 3)).toEqual([false, true, true]);
-  });
+describe("hiddenLines", () => {
+  for (const { name, ranges, folded, total, expected } of hiddenCases) {
+    it(name, () => {
+      expect(hiddenLines(ranges, new Set(folded), total)).toEqual(expected);
+    });
+  }
 });

--- a/frontend/src/components/source-fold.test.ts
+++ b/frontend/src/components/source-fold.test.ts
@@ -113,8 +113,7 @@ const hiddenCases: HiddenCase[] = [
 describe("hiddenLines", () => {
   for (const { name, ranges, folded, expected } of hiddenCases) {
     it(name, () => {
-      const got = [...hiddenLines(ranges, new Set(folded))].toSorted((a, b) => a - b);
-      expect(got).toEqual(expected);
+      expect(hiddenLines(ranges, new Set(folded))).toEqual(new Set(expected));
     });
   }
 });

--- a/frontend/src/components/source-fold.ts
+++ b/frontend/src/components/source-fold.ts
@@ -1,0 +1,92 @@
+export interface FoldRange {
+  startLine: number;
+  endLine: number;
+}
+
+const NEWLINE = /\r?\n/;
+
+export function computeFoldRanges(source: string): FoldRange[] {
+  const lines = source.split(NEWLINE);
+  const stack: number[] = [];
+  const ranges: FoldRange[] = [];
+  let inBlockComment = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let inString = false;
+    let j = 0;
+
+    while (j < line.length) {
+      const c = line[j];
+      const next = line[j + 1];
+
+      if (inBlockComment) {
+        if (c === "'" && next === "/") {
+          inBlockComment = false;
+          j += 2;
+          continue;
+        }
+        j++;
+        continue;
+      }
+
+      if (inString) {
+        if (c === "\\" && next !== undefined) {
+          j += 2;
+          continue;
+        }
+        if (c === '"') {
+          inString = false;
+        }
+        j++;
+        continue;
+      }
+
+      if (c === '"') {
+        inString = true;
+        j++;
+        continue;
+      }
+
+      if (c === "/" && next === "'") {
+        inBlockComment = true;
+        j += 2;
+        continue;
+      }
+
+      if (c === "'") {
+        break;
+      }
+
+      if (c === "{") {
+        stack.push(i);
+      } else if (c === "}") {
+        const start = stack.pop();
+        if (start !== undefined && i > start) {
+          ranges.push({ startLine: start, endLine: i });
+        }
+      }
+
+      j++;
+    }
+  }
+
+  ranges.sort((a, b) => a.startLine - b.startLine);
+  return ranges;
+}
+
+export function hiddenLines(
+  ranges: FoldRange[],
+  folded: ReadonlySet<number>,
+  total: number,
+): boolean[] {
+  const hidden: boolean[] = Array.from({ length: total }, () => false);
+  for (const r of ranges) {
+    if (!folded.has(r.startLine)) continue;
+    const end = Math.min(r.endLine, total - 1);
+    for (let i = r.startLine + 1; i <= end; i++) {
+      hidden[i] = true;
+    }
+  }
+  return hidden;
+}

--- a/frontend/src/components/source-fold.ts
+++ b/frontend/src/components/source-fold.ts
@@ -6,71 +6,24 @@ export interface FoldRange {
 export const FOLD_LABEL = "fold block";
 export const UNFOLD_LABEL = "unfold block";
 
-const NEWLINE = /\r?\n/;
+// PlantUML block comments (/'...'/), strings ("..."), and line comments ('...).
+// Matched together so brace counting only sees structural braces.
+const STRING_OR_COMMENT = /\/'[\s\S]*?'\/|"(?:\\.|[^"\\])*"|'[^\n]*/g;
 
 export function computeFoldRanges(source: string): FoldRange[] {
-  const lines = source.split(NEWLINE);
+  const masked = source.replace(STRING_OR_COMMENT, (m) => m.replace(/[^\n]/g, " "));
   const stack: number[] = [];
   const ranges: FoldRange[] = [];
-  let inBlockComment = false;
+  let line = 0;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    let inString = false;
-    let j = 0;
-
-    while (j < line.length) {
-      const c = line[j];
-      const next = line[j + 1];
-
-      if (inBlockComment) {
-        if (c === "'" && next === "/") {
-          inBlockComment = false;
-          j += 2;
-          continue;
-        }
-        j++;
-        continue;
+  for (const c of masked) {
+    if (c === "\n") line++;
+    else if (c === "{") stack.push(line);
+    else if (c === "}") {
+      const start = stack.pop();
+      if (start !== undefined && line > start) {
+        ranges.push({ startLine: start, endLine: line });
       }
-
-      if (inString) {
-        if (c === "\\" && next !== undefined) {
-          j += 2;
-          continue;
-        }
-        if (c === '"') {
-          inString = false;
-        }
-        j++;
-        continue;
-      }
-
-      if (c === '"') {
-        inString = true;
-        j++;
-        continue;
-      }
-
-      if (c === "/" && next === "'") {
-        inBlockComment = true;
-        j += 2;
-        continue;
-      }
-
-      if (c === "'") {
-        break;
-      }
-
-      if (c === "{") {
-        stack.push(i);
-      } else if (c === "}") {
-        const start = stack.pop();
-        if (start !== undefined && i > start) {
-          ranges.push({ startLine: start, endLine: i });
-        }
-      }
-
-      j++;
     }
   }
 
@@ -87,9 +40,7 @@ export function hiddenLines(
   for (const r of ranges) {
     if (!folded.has(r.startLine)) continue;
     const end = Math.min(r.endLine, total - 1);
-    for (let i = r.startLine + 1; i <= end; i++) {
-      hidden[i] = true;
-    }
+    for (let i = r.startLine + 1; i <= end; i++) hidden[i] = true;
   }
   return hidden;
 }

--- a/frontend/src/components/source-fold.ts
+++ b/frontend/src/components/source-fold.ts
@@ -3,6 +3,9 @@ export interface FoldRange {
   endLine: number;
 }
 
+export const FOLD_LABEL = "fold block";
+export const UNFOLD_LABEL = "unfold block";
+
 const NEWLINE = /\r?\n/;
 
 export function computeFoldRanges(source: string): FoldRange[] {

--- a/frontend/src/components/source-fold.ts
+++ b/frontend/src/components/source-fold.ts
@@ -6,23 +6,29 @@ export interface FoldRange {
 export const FOLD_LABEL = "fold block";
 export const UNFOLD_LABEL = "unfold block";
 
-// PlantUML block comments (/'...'/), strings ("..."), and line comments ('...).
-// Matched together so brace counting only sees structural braces.
-const STRING_OR_COMMENT = /\/'[\s\S]*?'\/|"(?:\\.|[^"\\])*"|'[^\n]*/g;
+// PlantUML block comments, strings, line comments, and structural braces /
+// newlines, in a single token alternation. Anything not matched (identifiers,
+// whitespace, etc.) is simply skipped between matches.
+const TOKEN = /\/'[\s\S]*?'\/|"(?:\\.|[^"\\])*"|'[^\n]*|[{}\n]/g;
 
 export function computeFoldRanges(source: string): FoldRange[] {
-  const masked = source.replace(STRING_OR_COMMENT, (m) => m.replace(/[^\n]/g, " "));
   const stack: number[] = [];
   const ranges: FoldRange[] = [];
   let line = 0;
 
-  for (const c of masked) {
-    if (c === "\n") line++;
-    else if (c === "{") stack.push(line);
-    else if (c === "}") {
+  for (const m of source.matchAll(TOKEN)) {
+    const tok = m[0];
+    if (tok === "{") {
+      stack.push(line);
+    } else if (tok === "}") {
       const start = stack.pop();
       if (start !== undefined && line > start) {
         ranges.push({ startLine: start, endLine: line });
+      }
+    } else {
+      // Newline token, or a string / block comment that may straddle lines.
+      for (let i = 0; i < tok.length; i++) {
+        if (tok.charCodeAt(i) === 10) line++;
       }
     }
   }
@@ -31,16 +37,11 @@ export function computeFoldRanges(source: string): FoldRange[] {
   return ranges;
 }
 
-export function hiddenLines(
-  ranges: FoldRange[],
-  folded: ReadonlySet<number>,
-  total: number,
-): boolean[] {
-  const hidden: boolean[] = Array.from({ length: total }, () => false);
+export function hiddenLines(ranges: FoldRange[], folded: ReadonlySet<number>): Set<number> {
+  const hidden = new Set<number>();
   for (const r of ranges) {
     if (!folded.has(r.startLine)) continue;
-    const end = Math.min(r.endLine, total - 1);
-    for (let i = r.startLine + 1; i <= end; i++) hidden[i] = true;
+    for (let i = r.startLine + 1; i <= r.endLine; i++) hidden.add(i);
   }
   return hidden;
 }

--- a/frontend/src/components/source-view.test.tsx
+++ b/frontend/src/components/source-view.test.tsx
@@ -2,11 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act } from "react";
 import { setupRender } from "../test/render";
 
-let codeToHtmlMock: ReturnType<typeof vi.fn>;
+interface ShikiToken {
+  content: string;
+  color?: string;
+}
+
+let codeToTokensMock: ReturnType<typeof vi.fn>;
 
 vi.mock("shiki/core", () => ({
   createHighlighterCore: vi.fn(async () => ({
-    codeToHtml: codeToHtmlMock,
+    codeToTokens: codeToTokensMock,
   })),
 }));
 
@@ -28,8 +33,22 @@ async function flushAsync(): Promise<void> {
   });
 }
 
+function tokenize(source: string): { tokens: ShikiToken[][]; fg: string; bg: string } {
+  return {
+    tokens: source.split(/\r?\n/).map((line) => [{ content: line, color: "#222" }]),
+    fg: "#222",
+    bg: "#fff",
+  };
+}
+
+function findFoldToggle(): HTMLButtonElement {
+  return document.querySelector(
+    'button[aria-label="fold block"], button[aria-label="unfold block"]',
+  ) as HTMLButtonElement;
+}
+
 beforeEach(() => {
-  codeToHtmlMock = vi.fn(() => "<pre class='shiki'>highlighted</pre>");
+  codeToTokensMock = vi.fn((source: string) => tokenize(source));
 });
 
 afterEach(() => {
@@ -44,20 +63,21 @@ describe("SourceView", () => {
     expect(document.querySelector("pre")).toBeNull();
   });
 
-  it("renders the highlighter output for a non-empty source", async () => {
+  it("renders one line per source line via the highlighter", async () => {
     const { SourceView } = await import("./source-view");
     render(<SourceView source={"@startuml\n@enduml\n"} />);
     await flushAsync();
 
-    expect(codeToHtmlMock).toHaveBeenCalledWith("@startuml\n@enduml\n", {
+    expect(codeToTokensMock).toHaveBeenCalledWith("@startuml\n@enduml\n", {
       lang: "yaml",
       theme: "github-light",
     });
-    expect(document.body.innerHTML).toContain("highlighted");
+    expect(document.body.textContent).toContain("@startuml");
+    expect(document.body.textContent).toContain("@enduml");
   });
 
-  it("falls back to escaped <pre> when the highlighter throws", async () => {
-    codeToHtmlMock.mockImplementation(() => {
+  it("falls back to a plain <pre> when the highlighter throws", async () => {
+    codeToTokensMock.mockImplementation(() => {
       throw new Error("boom");
     });
     const { SourceView } = await import("./source-view");
@@ -66,28 +86,76 @@ describe("SourceView", () => {
 
     const pre = document.querySelector("pre");
     expect(pre).not.toBeNull();
-    expect(pre!.innerHTML).toBe("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(pre!.textContent).toBe("<script>alert(1)</script>");
+    // React must have escaped the content; raw HTML must not be injected.
+    expect(pre!.querySelector("script")).toBeNull();
   });
 
-  it("escapes & < > characters in the fallback", async () => {
-    codeToHtmlMock.mockImplementation(() => {
-      throw new Error("nope");
-    });
-    const { SourceView } = await import("./source-view");
-    render(<SourceView source="a & b < c > d" />);
-    await flushAsync();
-
-    const pre = document.querySelector("pre");
-    expect(pre!.innerHTML).toBe("a &amp; b &lt; c &gt; d");
-  });
-
-  it("clears highlighted html when source becomes empty", async () => {
+  it("clears highlighted output when source becomes empty", async () => {
     const { SourceView } = await import("./source-view");
     render(<SourceView source="hello" />);
     await flushAsync();
-    expect(document.body.innerHTML).toContain("highlighted");
+    expect(document.body.textContent).toContain("hello");
 
     render(<SourceView source="" />);
     expect(document.body.textContent).toContain("no source");
+  });
+
+  describe("folding", () => {
+    const source = ["class A {", "  field1", "  field2", "}", "class B"].join("\n");
+
+    it("renders a fold toggle on the opening brace line", async () => {
+      const { SourceView } = await import("./source-view");
+      render(<SourceView source={source} />);
+      await flushAsync();
+
+      const buttons = document.querySelectorAll('button[aria-label="fold block"]');
+      expect(buttons.length).toBe(1);
+      expect(buttons[0].getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("hides the block body after clicking the toggle", async () => {
+      const { SourceView } = await import("./source-view");
+      render(<SourceView source={source} />);
+      await flushAsync();
+
+      const button = document.querySelector('button[aria-label="fold block"]') as HTMLButtonElement;
+      expect(button).not.toBeNull();
+
+      act(() => {
+        button.click();
+      });
+
+      expect(document.body.textContent).not.toContain("field1");
+      expect(document.body.textContent).not.toContain("field2");
+      expect(document.body.textContent).toContain("class A {");
+      expect(document.body.textContent).toContain("class B");
+
+      const unfoldBtn = document.querySelector(
+        'button[aria-label="unfold block"]',
+      ) as HTMLButtonElement;
+      expect(unfoldBtn).not.toBeNull();
+      expect(unfoldBtn.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("re-shows the block body after toggling back", async () => {
+      const { SourceView } = await import("./source-view");
+      render(<SourceView source={source} />);
+      await flushAsync();
+
+      act(() => findFoldToggle().click());
+      act(() => findFoldToggle().click());
+
+      expect(document.body.textContent).toContain("field1");
+      expect(document.body.textContent).toContain("field2");
+    });
+
+    it("does not show a fold toggle on lines without a brace block", async () => {
+      const { SourceView } = await import("./source-view");
+      render(<SourceView source={"@startuml\nactor User\n@enduml\n"} />);
+      await flushAsync();
+
+      expect(document.querySelector('button[aria-label="fold block"]')).toBeNull();
+    });
   });
 });

--- a/frontend/src/components/source-view.test.tsx
+++ b/frontend/src/components/source-view.test.tsx
@@ -2,11 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act } from "react";
 import { setupRender } from "../test/render";
 import { FOLD_LABEL, UNFOLD_LABEL } from "./source-fold";
-
-interface ShikiToken {
-  content: string;
-  color?: string;
-}
+import type { ShikiToken } from "./source-view";
 
 let codeToTokensMock: ReturnType<typeof vi.fn>;
 

--- a/frontend/src/components/source-view.test.tsx
+++ b/frontend/src/components/source-view.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act } from "react";
 import { setupRender } from "../test/render";
+import { FOLD_LABEL, UNFOLD_LABEL } from "./source-fold";
 
 interface ShikiToken {
   content: string;
@@ -43,7 +44,7 @@ function tokenize(source: string): { tokens: ShikiToken[][]; fg: string; bg: str
 
 function findFoldToggle(): HTMLButtonElement {
   return document.querySelector(
-    'button[aria-label="fold block"], button[aria-label="unfold block"]',
+    `button[aria-label="${FOLD_LABEL}"], button[aria-label="${UNFOLD_LABEL}"]`,
   ) as HTMLButtonElement;
 }
 
@@ -109,7 +110,7 @@ describe("SourceView", () => {
       render(<SourceView source={source} />);
       await flushAsync();
 
-      const buttons = document.querySelectorAll('button[aria-label="fold block"]');
+      const buttons = document.querySelectorAll(`button[aria-label="${FOLD_LABEL}"]`);
       expect(buttons.length).toBe(1);
       expect(buttons[0].getAttribute("aria-expanded")).toBe("true");
     });
@@ -119,7 +120,9 @@ describe("SourceView", () => {
       render(<SourceView source={source} />);
       await flushAsync();
 
-      const button = document.querySelector('button[aria-label="fold block"]') as HTMLButtonElement;
+      const button = document.querySelector(
+        `button[aria-label="${FOLD_LABEL}"]`,
+      ) as HTMLButtonElement;
       expect(button).not.toBeNull();
 
       act(() => {
@@ -132,7 +135,7 @@ describe("SourceView", () => {
       expect(document.body.textContent).toContain("class B");
 
       const unfoldBtn = document.querySelector(
-        'button[aria-label="unfold block"]',
+        `button[aria-label="${UNFOLD_LABEL}"]`,
       ) as HTMLButtonElement;
       expect(unfoldBtn).not.toBeNull();
       expect(unfoldBtn.getAttribute("aria-expanded")).toBe("false");
@@ -155,7 +158,7 @@ describe("SourceView", () => {
       render(<SourceView source={"@startuml\nactor User\n@enduml\n"} />);
       await flushAsync();
 
-      expect(document.querySelector('button[aria-label="fold block"]')).toBeNull();
+      expect(document.querySelector(`button[aria-label="${FOLD_LABEL}"]`)).toBeNull();
     });
   });
 });

--- a/frontend/src/components/source-view.tsx
+++ b/frontend/src/components/source-view.tsx
@@ -44,11 +44,7 @@ export function SourceView({ source }: Props): JSX.Element {
 
   const lines = useMemo(() => source.split(/\r?\n/), [source]);
   const ranges = useMemo<FoldRange[]>(() => computeFoldRanges(source), [source]);
-  const rangeByStart = useMemo(() => {
-    const m = new Map<number, FoldRange>();
-    for (const r of ranges) m.set(r.startLine, r);
-    return m;
-  }, [ranges]);
+  const foldStarts = useMemo(() => new Set(ranges.map((r) => r.startLine)), [ranges]);
 
   const tokenLines = useMemo<ShikiToken[][]>(() => {
     const base = highlighted?.tokens ?? lines.map((l) => [{ content: l }]);
@@ -58,10 +54,7 @@ export function SourceView({ source }: Props): JSX.Element {
     return padded;
   }, [highlighted, lines]);
 
-  const hidden = useMemo(
-    () => hiddenLines(ranges, folded, lines.length),
-    [ranges, folded, lines.length],
-  );
+  const hidden = useMemo(() => hiddenLines(ranges, folded), [ranges, folded]);
 
   useEffect(() => {
     let cancelled = false;
@@ -114,16 +107,16 @@ export function SourceView({ source }: Props): JSX.Element {
       }}
     >
       {tokenLines.map((tokens, i) => {
-        if (hidden[i]) return null;
-        const range = rangeByStart.get(i);
-        const isFolded = range !== undefined && folded.has(i);
+        if (hidden.has(i)) return null;
+        const isStart = foldStarts.has(i);
+        const isFolded = isStart && folded.has(i);
         return (
           <div key={i} className="flex items-start">
             <span
               className="inline-block w-4 shrink-0 select-none text-center text-slate-400"
-              aria-hidden={range === undefined}
+              aria-hidden={!isStart}
             >
-              {range !== undefined && (
+              {isStart && (
                 <button
                   type="button"
                   aria-label={isFolded ? UNFOLD_LABEL : FOLD_LABEL}

--- a/frontend/src/components/source-view.tsx
+++ b/frontend/src/components/source-view.tsx
@@ -1,6 +1,19 @@
-import { useEffect, useState, type JSX } from "react";
+import { useEffect, useMemo, useState, type JSX } from "react";
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
+import { computeFoldRanges, hiddenLines, type FoldRange } from "./source-fold";
+
+interface ShikiToken {
+  content: string;
+  color?: string;
+  fontStyle?: number;
+}
+
+interface Highlighted {
+  tokens: ShikiToken[][];
+  fg: string;
+  bg: string;
+}
 
 let highlighterPromise: Promise<HighlighterCore> | null = null;
 
@@ -20,27 +33,43 @@ interface Props {
 }
 
 export function SourceView({ source }: Props): JSX.Element {
-  const [html, setHtml] = useState<string>("");
+  const [highlighted, setHighlighted] = useState<Highlighted | null>(null);
+  const [error, setError] = useState<boolean>(false);
+  const [folded, setFolded] = useState<Set<number>>(() => new Set());
+
+  const lines = useMemo(() => source.split(/\r?\n/), [source]);
+  const ranges = useMemo<FoldRange[]>(() => computeFoldRanges(source), [source]);
+  const rangeByStart = useMemo(() => {
+    const m = new Map<number, FoldRange>();
+    for (const r of ranges) m.set(r.startLine, r);
+    return m;
+  }, [ranges]);
 
   useEffect(() => {
     let cancelled = false;
     if (!source) {
-      setHtml("");
+      setHighlighted(null);
+      setError(false);
       return;
     }
+    setError(false);
     void getHighlighter().then((highlighter) => {
       if (cancelled) return;
       try {
-        setHtml(
-          highlighter.codeToHtml(source, {
-            // PlantUML isn't a built-in shiki grammar; YAML produces
-            // reasonable token coloring for arrow/keyword-like lines.
-            lang: "yaml",
-            theme: "github-light",
-          }),
-        );
+        const result = highlighter.codeToTokens(source, {
+          // PlantUML isn't a built-in shiki grammar; YAML produces
+          // reasonable token coloring for arrow/keyword-like lines.
+          lang: "yaml",
+          theme: "github-light",
+        });
+        setHighlighted({
+          tokens: result.tokens as ShikiToken[][],
+          fg: result.fg ?? "",
+          bg: result.bg ?? "",
+        });
       } catch {
-        setHtml(`<pre>${escapeHtml(source)}</pre>`);
+        setHighlighted(null);
+        setError(true);
       }
     });
     return () => {
@@ -51,16 +80,73 @@ export function SourceView({ source }: Props): JSX.Element {
   if (!source) {
     return <p className="px-4 py-3 text-sm text-slate-400">no source</p>;
   }
+
+  if (error) {
+    return <pre className="m-0 overflow-auto bg-white p-3 font-mono text-xs">{source}</pre>;
+  }
+
+  const toggle = (start: number): void => {
+    setFolded((prev) => {
+      const next = new Set(prev);
+      if (next.has(start)) next.delete(start);
+      else next.add(start);
+      return next;
+    });
+  };
+
+  const hidden = hiddenLines(ranges, folded, lines.length);
+
+  const tokenLines: ShikiToken[][] = highlighted?.tokens ?? lines.map((l) => [{ content: l }]);
+
+  while (tokenLines.length < lines.length) {
+    tokenLines.push([{ content: "" }]);
+  }
+
   return (
     <div
-      className="text-xs [&_pre]:p-3 [&_pre]:bg-white [&_pre]:overflow-auto"
-      dangerouslySetInnerHTML={{
-        __html: html || `<pre>${escapeHtml(source)}</pre>`,
+      role="group"
+      aria-label="source"
+      className="overflow-auto font-mono text-xs leading-5"
+      style={{
+        color: highlighted?.fg || undefined,
+        backgroundColor: highlighted?.bg || undefined,
       }}
-    />
+    >
+      <pre className="m-0 p-3">
+        {tokenLines.map((tokens, i) => {
+          if (hidden[i]) return null;
+          const range = rangeByStart.get(i);
+          const isFolded = range !== undefined && folded.has(i);
+          return (
+            <div key={i} className="flex items-start">
+              <span
+                className="inline-block w-4 shrink-0 select-none text-center text-slate-400"
+                aria-hidden={range === undefined}
+              >
+                {range !== undefined && (
+                  <button
+                    type="button"
+                    aria-label={isFolded ? "unfold block" : "fold block"}
+                    aria-expanded={!isFolded}
+                    onClick={() => toggle(i)}
+                    className="cursor-pointer text-slate-400 hover:text-slate-700"
+                  >
+                    {isFolded ? "▶" : "▼"}
+                  </button>
+                )}
+              </span>
+              <span className="min-w-0 flex-1 whitespace-pre">
+                {tokens.map((t, j) => (
+                  <span key={j} style={t.color ? { color: t.color } : undefined}>
+                    {t.content}
+                  </span>
+                ))}
+                {isFolded && <span className="text-slate-400"> … </span>}
+              </span>
+            </div>
+          );
+        })}
+      </pre>
+    </div>
   );
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }

--- a/frontend/src/components/source-view.tsx
+++ b/frontend/src/components/source-view.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useMemo, useState, type JSX } from "react";
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
-import { computeFoldRanges, hiddenLines, type FoldRange } from "./source-fold";
+import {
+  computeFoldRanges,
+  FOLD_LABEL,
+  hiddenLines,
+  UNFOLD_LABEL,
+  type FoldRange,
+} from "./source-fold";
 
 interface ShikiToken {
   content: string;
@@ -34,7 +40,6 @@ interface Props {
 
 export function SourceView({ source }: Props): JSX.Element {
   const [highlighted, setHighlighted] = useState<Highlighted | null>(null);
-  const [error, setError] = useState<boolean>(false);
   const [folded, setFolded] = useState<Set<number>>(() => new Set());
 
   const lines = useMemo(() => source.split(/\r?\n/), [source]);
@@ -45,14 +50,25 @@ export function SourceView({ source }: Props): JSX.Element {
     return m;
   }, [ranges]);
 
+  const tokenLines = useMemo<ShikiToken[][]>(() => {
+    const base = highlighted?.tokens ?? lines.map((l) => [{ content: l }]);
+    if (base.length >= lines.length) return base;
+    const padded = base.slice();
+    while (padded.length < lines.length) padded.push([{ content: "" }]);
+    return padded;
+  }, [highlighted, lines]);
+
+  const hidden = useMemo(
+    () => hiddenLines(ranges, folded, lines.length),
+    [ranges, folded, lines.length],
+  );
+
   useEffect(() => {
     let cancelled = false;
     if (!source) {
       setHighlighted(null);
-      setError(false);
       return;
     }
-    setError(false);
     void getHighlighter().then((highlighter) => {
       if (cancelled) return;
       try {
@@ -69,7 +85,6 @@ export function SourceView({ source }: Props): JSX.Element {
         });
       } catch {
         setHighlighted(null);
-        setError(true);
       }
     });
     return () => {
@@ -81,10 +96,6 @@ export function SourceView({ source }: Props): JSX.Element {
     return <p className="px-4 py-3 text-sm text-slate-400">no source</p>;
   }
 
-  if (error) {
-    return <pre className="m-0 overflow-auto bg-white p-3 font-mono text-xs">{source}</pre>;
-  }
-
   const toggle = (start: number): void => {
     setFolded((prev) => {
       const next = new Set(prev);
@@ -94,59 +105,47 @@ export function SourceView({ source }: Props): JSX.Element {
     });
   };
 
-  const hidden = hiddenLines(ranges, folded, lines.length);
-
-  const tokenLines: ShikiToken[][] = highlighted?.tokens ?? lines.map((l) => [{ content: l }]);
-
-  while (tokenLines.length < lines.length) {
-    tokenLines.push([{ content: "" }]);
-  }
-
   return (
-    <div
-      role="group"
-      aria-label="source"
-      className="overflow-auto font-mono text-xs leading-5"
+    <pre
+      className="m-0 overflow-auto p-3 font-mono text-xs leading-5"
       style={{
         color: highlighted?.fg || undefined,
         backgroundColor: highlighted?.bg || undefined,
       }}
     >
-      <pre className="m-0 p-3">
-        {tokenLines.map((tokens, i) => {
-          if (hidden[i]) return null;
-          const range = rangeByStart.get(i);
-          const isFolded = range !== undefined && folded.has(i);
-          return (
-            <div key={i} className="flex items-start">
-              <span
-                className="inline-block w-4 shrink-0 select-none text-center text-slate-400"
-                aria-hidden={range === undefined}
-              >
-                {range !== undefined && (
-                  <button
-                    type="button"
-                    aria-label={isFolded ? "unfold block" : "fold block"}
-                    aria-expanded={!isFolded}
-                    onClick={() => toggle(i)}
-                    className="cursor-pointer text-slate-400 hover:text-slate-700"
-                  >
-                    {isFolded ? "▶" : "▼"}
-                  </button>
-                )}
-              </span>
-              <span className="min-w-0 flex-1 whitespace-pre">
-                {tokens.map((t, j) => (
-                  <span key={j} style={t.color ? { color: t.color } : undefined}>
-                    {t.content}
-                  </span>
-                ))}
-                {isFolded && <span className="text-slate-400"> … </span>}
-              </span>
-            </div>
-          );
-        })}
-      </pre>
-    </div>
+      {tokenLines.map((tokens, i) => {
+        if (hidden[i]) return null;
+        const range = rangeByStart.get(i);
+        const isFolded = range !== undefined && folded.has(i);
+        return (
+          <div key={i} className="flex items-start">
+            <span
+              className="inline-block w-4 shrink-0 select-none text-center text-slate-400"
+              aria-hidden={range === undefined}
+            >
+              {range !== undefined && (
+                <button
+                  type="button"
+                  aria-label={isFolded ? UNFOLD_LABEL : FOLD_LABEL}
+                  aria-expanded={!isFolded}
+                  onClick={() => toggle(i)}
+                  className="cursor-pointer text-slate-400 hover:text-slate-700"
+                >
+                  {isFolded ? "▶" : "▼"}
+                </button>
+              )}
+            </span>
+            <span className="min-w-0 flex-1 whitespace-pre">
+              {tokens.map((t, j) => (
+                <span key={j} style={t.color ? { color: t.color } : undefined}>
+                  {t.content}
+                </span>
+              ))}
+              {isFolded && <span className="text-slate-400"> … </span>}
+            </span>
+          </div>
+        );
+      })}
+    </pre>
   );
 }

--- a/frontend/src/components/source-view.tsx
+++ b/frontend/src/components/source-view.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type JSX } from "react";
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
+import { useToggleSet } from "../hooks/useToggleSet";
 import {
   computeFoldRanges,
   FOLD_LABEL,
@@ -9,7 +10,7 @@ import {
   type FoldRange,
 } from "./source-fold";
 
-interface ShikiToken {
+export interface ShikiToken {
   content: string;
   color?: string;
   fontStyle?: number;
@@ -40,7 +41,7 @@ interface Props {
 
 export function SourceView({ source }: Props): JSX.Element {
   const [highlighted, setHighlighted] = useState<Highlighted | null>(null);
-  const [folded, setFolded] = useState<Set<number>>(() => new Set());
+  const [folded, toggle] = useToggleSet<number>();
 
   const lines = useMemo(() => source.split(/\r?\n/), [source]);
   const ranges = useMemo<FoldRange[]>(() => computeFoldRanges(source), [source]);
@@ -88,15 +89,6 @@ export function SourceView({ source }: Props): JSX.Element {
   if (!source) {
     return <p className="px-4 py-3 text-sm text-slate-400">no source</p>;
   }
-
-  const toggle = (start: number): void => {
-    setFolded((prev) => {
-      const next = new Set(prev);
-      if (next.has(start)) next.delete(start);
-      else next.add(start);
-      return next;
-    });
-  };
 
   return (
     <pre

--- a/frontend/src/hooks/useToggleSet.ts
+++ b/frontend/src/hooks/useToggleSet.ts
@@ -1,0 +1,14 @@
+import { useCallback, useState } from "react";
+
+export function useToggleSet<T>(): readonly [Set<T>, (key: T) => void] {
+  const [set, setSet] = useState<Set<T>>(() => new Set());
+  const toggle = useCallback((key: T): void => {
+    setSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+  return [set, toggle] as const;
+}

--- a/frontend/tests/e2e/source-fold.spec.ts
+++ b/frontend/tests/e2e/source-fold.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("source folding", () => {
+  test("folds and unfolds a brace block", async ({ page }) => {
+    await page.goto("/");
+
+    const preview = page.getByAltText("preview");
+    await expect(preview).toBeVisible({ timeout: 60_000 });
+
+    await page.getByRole("button", { name: "class.puml" }).click();
+    await expect(preview).toBeVisible();
+
+    const sourceRegion = page.getByRole("region", { name: "Source" });
+    await expect(sourceRegion.getByText("+registry: Registry")).toBeVisible();
+
+    const foldButtons = sourceRegion.getByRole("button", { name: "fold block" });
+    await expect(foldButtons.first()).toBeVisible();
+    const initialFolds = await foldButtons.count();
+    expect(initialFolds).toBeGreaterThan(0);
+
+    await foldButtons.first().click();
+
+    await expect(sourceRegion.getByText("+registry: Registry")).toBeHidden();
+    await expect(
+      sourceRegion.getByRole("button", { name: "unfold block" }).first(),
+    ).toBeVisible();
+
+    await sourceRegion.getByRole("button", { name: "unfold block" }).first().click();
+    await expect(sourceRegion.getByText("+registry: Registry")).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/source-fold.spec.ts
+++ b/frontend/tests/e2e/source-fold.spec.ts
@@ -3,30 +3,36 @@ import { FOLD_LABEL, UNFOLD_LABEL } from "../../src/components/source-fold";
 
 test.describe("source folding", () => {
   test("folds and unfolds a brace block", async ({ page }) => {
-    await page.goto("/");
-
     const preview = page.getByAltText("preview");
-    await expect(preview).toBeVisible({ timeout: 60_000 });
-
-    await page.getByRole("button", { name: "class.puml" }).click();
-    await expect(preview).toBeVisible();
-
     const sourceRegion = page.getByRole("region", { name: "Source" });
-    await expect(sourceRegion.getByText("+registry: Registry")).toBeVisible();
+    const fieldRow = sourceRegion.getByText("+registry: Registry");
+    const foldToggle = sourceRegion.getByRole("button", { name: FOLD_LABEL }).first();
+    const unfoldToggle = sourceRegion.getByRole("button", { name: UNFOLD_LABEL }).first();
 
-    const foldButtons = sourceRegion.getByRole("button", { name: FOLD_LABEL });
-    await expect(foldButtons.first()).toBeVisible();
-    const initialFolds = await foldButtons.count();
-    expect(initialFolds).toBeGreaterThan(0);
+    await test.step("open class.puml and wait for the preview to render", async () => {
+      await page.goto("/");
+      await expect(preview).toBeVisible({ timeout: 60_000 });
+      await page.getByRole("button", { name: "class.puml" }).click();
+      await expect(preview).toBeVisible();
+      await expect(fieldRow).toBeVisible();
+    });
 
-    await foldButtons.first().click();
+    await test.step("source panel shows at least one fold toggle", async () => {
+      await expect(foldToggle).toBeVisible();
+      expect(await sourceRegion.getByRole("button", { name: FOLD_LABEL }).count()).toBeGreaterThan(
+        0,
+      );
+    });
 
-    await expect(sourceRegion.getByText("+registry: Registry")).toBeHidden();
-    await expect(
-      sourceRegion.getByRole("button", { name: UNFOLD_LABEL }).first(),
-    ).toBeVisible();
+    await test.step("clicking the toggle hides the block body", async () => {
+      await foldToggle.click();
+      await expect(fieldRow).toBeHidden();
+      await expect(unfoldToggle).toBeVisible();
+    });
 
-    await sourceRegion.getByRole("button", { name: UNFOLD_LABEL }).first().click();
-    await expect(sourceRegion.getByText("+registry: Registry")).toBeVisible();
+    await test.step("clicking again restores the block body", async () => {
+      await unfoldToggle.click();
+      await expect(fieldRow).toBeVisible();
+    });
   });
 });

--- a/frontend/tests/e2e/source-fold.spec.ts
+++ b/frontend/tests/e2e/source-fold.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { FOLD_LABEL, UNFOLD_LABEL } from "../../src/components/source-fold";
 
 test.describe("source folding", () => {
   test("folds and unfolds a brace block", async ({ page }) => {
@@ -13,7 +14,7 @@ test.describe("source folding", () => {
     const sourceRegion = page.getByRole("region", { name: "Source" });
     await expect(sourceRegion.getByText("+registry: Registry")).toBeVisible();
 
-    const foldButtons = sourceRegion.getByRole("button", { name: "fold block" });
+    const foldButtons = sourceRegion.getByRole("button", { name: FOLD_LABEL });
     await expect(foldButtons.first()).toBeVisible();
     const initialFolds = await foldButtons.count();
     expect(initialFolds).toBeGreaterThan(0);
@@ -22,10 +23,10 @@ test.describe("source folding", () => {
 
     await expect(sourceRegion.getByText("+registry: Registry")).toBeHidden();
     await expect(
-      sourceRegion.getByRole("button", { name: "unfold block" }).first(),
+      sourceRegion.getByRole("button", { name: UNFOLD_LABEL }).first(),
     ).toBeVisible();
 
-    await sourceRegion.getByRole("button", { name: "unfold block" }).first().click();
+    await sourceRegion.getByRole("button", { name: UNFOLD_LABEL }).first().click();
     await expect(sourceRegion.getByText("+registry: Registry")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

The source panel can get cramped on big diagrams, so this PR makes brace-delimited entity blocks (class, package, entity, node, state, component, ...) collapsible.

- Switch `SourceView` from shiki's `codeToHtml` to `codeToTokens` and render lines as React rows so a fold gutter can be attached per line.
- Each line that opens a `{ ... }` block gets a `▼` / `▶` toggle in the gutter. When folded the body is hidden and a `…` indicator is shown after the opening brace.
- Fold-range detection lives in `frontend/src/components/source-fold.ts`. The scanner is quote- and comment-aware so braces inside double-quoted strings, `'` line comments, and `/' ... '/` block comments don't start a range.
- Fold state is held as `Set<number>` of opening-line indices and is preserved across live-reload updates of the same file (keyed by line index, so unchanged blocks stay folded).
- `FOLD_LABEL` / `UNFOLD_LABEL` aria-label constants are exported and reused from the component, unit tests, and e2e spec.

Works for any PlantUML diagram type that uses braces (verified with `examples/class.puml` and `examples/large-er.puml`). Sequence diagrams without braces render unchanged.

## Test plan

- [x] `make test-frontend` — fold-range logic (15 cases, table-driven) and `SourceView` fold interaction tests pass; 86 frontend tests total.
- [x] `make lint` (frontend) — `oxlint` / `oxfmt` clean.
- [x] `pnpm exec tsc --noEmit` — type check clean.
- [x] `make build` — frontend bundle + Go binary build successfully.
- [x] `make e2e` — all 7 specs pass locally (including the new `tests/e2e/source-fold.spec.ts`) against the built binary. Ran via a temporary local Playwright config pointing at a bundled Chromium because the sandbox lacks Google Chrome stable; the committed `playwright.config.ts` is unchanged and CI runs Chrome as before.
- [x] Visual verification: screenshots taken of `class.puml` and `large-er.puml` in both expanded and partially-folded states, confirming the gutter toggles, `…` indicator after the opening brace, and that the rendered preview is unaffected.