### PR TITLE
perf(frontend): skip setFiles when fetched list matches current state

### DIFF
--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type JSX } from "react";
-import { fetchFiles, fetchFileSource, type FileEntry } from "./api/files";
+import { fetchFiles, fetchFileSource, sameFilePaths, type FileEntry } from "./api/files";
 import { subscribe } from "./api/events";
 import { renderPlantUML } from "./plantuml/renderer";
 import { FileTree } from "./components/file-tree";
@@ -32,7 +32,7 @@ export default function App(): JSX.Element {
   useEffect(() => {
     void (async () => {
       const list = await fetchFiles();
-      setFiles(list);
+      setFiles((prev) => (sameFilePaths(prev, list) ? prev : list));
       setActive((prev) =>
         prev && list.some((f) => f.path === prev) ? prev : (list[0]?.path ?? null),
       );

--- a/internal/frontend/src/api/files.test.ts
+++ b/internal/frontend/src/api/files.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { fetchFileSource, fetchFiles, type FileEntry } from "./files";
+import { fetchFileSource, fetchFiles, sameFilePaths, type FileEntry } from "./files";
 
 const originalFetch = globalThis.fetch;
 
@@ -114,5 +114,46 @@ describe("fetchFileSource", () => {
     } as unknown as Response) as unknown as typeof fetch;
 
     await expect(fetchFileSource("/tmp/x.puml")).rejects.toThrow(/failed to load source: 503/);
+  });
+});
+
+function entry(path: string): FileEntry {
+  return {
+    path,
+    rel: path.replace(/^\//, ""),
+    name: path.split("/").pop()!,
+    source: "/",
+  };
+}
+
+describe("sameFilePaths", () => {
+  it("returns true for two empty lists", () => {
+    expect(sameFilePaths([], [])).toBe(true);
+  });
+
+  it("returns true when both lists have the same paths in the same order", () => {
+    const a = [entry("/a.puml"), entry("/b.puml")];
+    const b = [entry("/a.puml"), entry("/b.puml")];
+    expect(sameFilePaths(a, b)).toBe(true);
+  });
+
+  it("returns true when only non-path fields differ", () => {
+    const a: FileEntry[] = [{ path: "/a.puml", rel: "a.puml", name: "a.puml", source: "/" }];
+    const b: FileEntry[] = [{ path: "/a.puml", rel: "x", name: "x", source: "/different" }];
+    expect(sameFilePaths(a, b)).toBe(true);
+  });
+
+  it("returns false when lengths differ", () => {
+    expect(sameFilePaths([entry("/a.puml")], [entry("/a.puml"), entry("/b.puml")])).toBe(false);
+  });
+
+  it("returns false when a path differs", () => {
+    expect(sameFilePaths([entry("/a.puml")], [entry("/b.puml")])).toBe(false);
+  });
+
+  it("returns false when order differs", () => {
+    const a = [entry("/a.puml"), entry("/b.puml")];
+    const b = [entry("/b.puml"), entry("/a.puml")];
+    expect(sameFilePaths(a, b)).toBe(false);
   });
 });

--- a/internal/frontend/src/api/files.test.ts
+++ b/internal/frontend/src/api/files.test.ts
@@ -127,33 +127,39 @@ function entry(path: string): FileEntry {
 }
 
 describe("sameFilePaths", () => {
-  it("returns true for two empty lists", () => {
-    expect(sameFilePaths([], [])).toBe(true);
-  });
-
-  it("returns true when both lists have the same paths in the same order", () => {
-    const a = [entry("/a.puml"), entry("/b.puml")];
-    const b = [entry("/a.puml"), entry("/b.puml")];
-    expect(sameFilePaths(a, b)).toBe(true);
-  });
-
-  it("returns true when only non-path fields differ", () => {
-    const a: FileEntry[] = [{ path: "/a.puml", rel: "a.puml", name: "a.puml", source: "/" }];
-    const b: FileEntry[] = [{ path: "/a.puml", rel: "x", name: "x", source: "/different" }];
-    expect(sameFilePaths(a, b)).toBe(true);
-  });
-
-  it("returns false when lengths differ", () => {
-    expect(sameFilePaths([entry("/a.puml")], [entry("/a.puml"), entry("/b.puml")])).toBe(false);
-  });
-
-  it("returns false when a path differs", () => {
-    expect(sameFilePaths([entry("/a.puml")], [entry("/b.puml")])).toBe(false);
-  });
-
-  it("returns false when order differs", () => {
-    const a = [entry("/a.puml"), entry("/b.puml")];
-    const b = [entry("/b.puml"), entry("/a.puml")];
-    expect(sameFilePaths(a, b)).toBe(false);
+  it.each([
+    { name: "two empty lists", a: [], b: [], want: true },
+    {
+      name: "same paths in the same order",
+      a: [entry("/a.puml"), entry("/b.puml")],
+      b: [entry("/a.puml"), entry("/b.puml")],
+      want: true,
+    },
+    {
+      name: "only non-path fields differ",
+      a: [{ path: "/a.puml", rel: "a.puml", name: "a.puml", source: "/" }] as FileEntry[],
+      b: [{ path: "/a.puml", rel: "x", name: "x", source: "/different" }] as FileEntry[],
+      want: true,
+    },
+    {
+      name: "lengths differ",
+      a: [entry("/a.puml")],
+      b: [entry("/a.puml"), entry("/b.puml")],
+      want: false,
+    },
+    {
+      name: "a path differs",
+      a: [entry("/a.puml")],
+      b: [entry("/b.puml")],
+      want: false,
+    },
+    {
+      name: "order differs",
+      a: [entry("/a.puml"), entry("/b.puml")],
+      b: [entry("/b.puml"), entry("/a.puml")],
+      want: false,
+    },
+  ])("$name -> $want", ({ a, b, want }) => {
+    expect(sameFilePaths(a, b)).toBe(want);
   });
 });

--- a/internal/frontend/src/api/files.ts
+++ b/internal/frontend/src/api/files.ts
@@ -20,3 +20,7 @@ export async function fetchFileSource(path: string): Promise<string> {
   }
   return res.text();
 }
+
+export function sameFilePaths(a: FileEntry[], b: FileEntry[]): boolean {
+  return a.length === b.length && a.every((f, i) => f.path === b[i]!.path);
+}


### PR DESCRIPTION
## Summary

- Add `sameFilePaths(a, b)` helper in `internal/frontend/src/api/files.ts` that compares two `FileEntry[]` by `path` and length.
- In `App.tsx`, swap the unconditional `setFiles(list)` for `setFiles((prev) => sameFilePaths(prev, list) ? prev : list)` so React bails on `Object.is` when an SSE-driven `fetchFiles()` returns an identical list — no re-render, no `buildTree` churn.
- Cover the no-op case (plus a few other edges: empty lists, length mismatch, path mismatch, order swap, identical paths with differing non-path fields) in `internal/frontend/src/api/files.test.ts`.

## Test plan

- [x] `make test-frontend` — 139/139 passing, including the new `sameFilePaths` suite.
- [x] `make lint-frontend` — clean (oxfmt + oxlint, 0 warnings).
- [ ] Manual UI verification not run in this environment; the behavior is "fewer re-renders" so there is no visible change to observe, and the helper test directly asserts the no-op contract.

Closes #32

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMGLaVjw8o9cBfRZYj14bx)_