### PR TITLE
feat(frontend): abort in-flight fetch on file switch and unmount

### DIFF
--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -27,8 +27,6 @@ export default function App(): JSX.Element {
   const activeRef = useRef<string | null>(null);
   activeRef.current = active;
 
-  const renderSeq = useRef(0);
-
   useEffect(() => {
     void (async () => {
       const list = await fetchFiles();
@@ -41,29 +39,30 @@ export default function App(): JSX.Element {
 
   useEffect(() => {
     if (!active) {
-      renderSeq.current++;
       setSource("");
       setRender({ kind: "idle" });
       return;
     }
 
-    const seq = ++renderSeq.current;
+    const controller = new AbortController();
     setRender({ kind: "loading" });
 
     void (async () => {
       try {
-        const src = await fetchFileSource(active);
-        if (seq !== renderSeq.current) return;
+        const src = await fetchFileSource(active, controller.signal);
+        if (controller.signal.aborted) return;
         setSource(src);
         const svg = await renderPlantUML(src);
-        if (seq !== renderSeq.current) return;
+        if (controller.signal.aborted) return;
         setRender({ kind: "ok", svg });
       } catch (e) {
-        if (seq !== renderSeq.current) return;
+        if (controller.signal.aborted) return;
         const message = e instanceof Error ? e.message : String(e);
         setRender({ kind: "error", message });
       }
     })();
+
+    return () => controller.abort();
   }, [active, activeReloadKey]);
 
   useEffect(() => {

--- a/internal/frontend/src/api/files.test.ts
+++ b/internal/frontend/src/api/files.test.ts
@@ -84,7 +84,9 @@ describe("fetchFileSource", () => {
 
     const body = await fetchFileSource("/tmp/a b.puml");
     expect(body).toBe("@startuml\n@enduml\n");
-    expect(mock).toHaveBeenCalledWith("/api/file?path=%2Ftmp%2Fa%20b.puml");
+    expect(mock).toHaveBeenCalledWith("/api/file?path=%2Ftmp%2Fa%20b.puml", {
+      signal: undefined,
+    });
   });
 
   it("encodes non-ASCII paths", async () => {
@@ -95,7 +97,9 @@ describe("fetchFileSource", () => {
     globalThis.fetch = mock as unknown as typeof fetch;
 
     await fetchFileSource("/tmp/日本語.puml");
-    expect(mock).toHaveBeenCalledWith(`/api/file?path=${encodeURIComponent("/tmp/日本語.puml")}`);
+    expect(mock).toHaveBeenCalledWith(`/api/file?path=${encodeURIComponent("/tmp/日本語.puml")}`, {
+      signal: undefined,
+    });
   });
 
   it("returns an empty string for an empty file", async () => {
@@ -114,5 +118,35 @@ describe("fetchFileSource", () => {
     } as unknown as Response) as unknown as typeof fetch;
 
     await expect(fetchFileSource("/tmp/x.puml")).rejects.toThrow(/failed to load source: 503/);
+  });
+
+  it("forwards the AbortSignal to fetch", async () => {
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    } as unknown as Response);
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    await fetchFileSource("/tmp/x.puml", controller.signal);
+
+    expect(mock).toHaveBeenCalledWith("/api/file?path=%2Ftmp%2Fx.puml", {
+      signal: controller.signal,
+    });
+  });
+
+  it("rejects with the abort reason when the signal aborts mid-flight", async () => {
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      })) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    const pending = fetchFileSource("/tmp/x.puml", controller.signal);
+    controller.abort();
+
+    await expect(pending).rejects.toThrow(/aborted/);
   });
 });

--- a/internal/frontend/src/api/files.ts
+++ b/internal/frontend/src/api/files.ts
@@ -13,8 +13,8 @@ export async function fetchFiles(): Promise<FileEntry[]> {
   return (await res.json()) as FileEntry[];
 }
 
-export async function fetchFileSource(path: string): Promise<string> {
-  const res = await fetch(`/api/file?path=${encodeURIComponent(path)}`);
+export async function fetchFileSource(path: string, signal?: AbortSignal): Promise<string> {
+  const res = await fetch(`/api/file?path=${encodeURIComponent(path)}`, { signal });
   if (!res.ok) {
     throw new Error(`failed to load source: ${res.status}`);
   }


### PR DESCRIPTION
Closes #31.

## Summary

- Thread `AbortSignal` through `fetchFileSource(path, signal?)`.
- In `App.tsx`'s active-load effect, own an `AbortController` per run and abort it from the cleanup. Replaces the `renderSeq` cancel-token entirely (the abort signal carries the same semantics).
- Switching files mid-fetch now cuts the network round-trip instead of letting it finish in the background. Unmount no longer leaves a fetch dangling.
- `renderPlantUML` (TeaVM, synchronous-in-a-Promise) still cannot be aborted — only the fetch can — but the `controller.signal.aborted` guard after each `await` keeps stale renders from clobbering the new file's state.

## Test plan

- [x] `make test-frontend` (135 passed, includes 2 new tests covering signal pass-through + abort propagation)
- [x] `make lint`
- [x] `make test-backend` (server tests pass at 85.1%; toolchain-side `covdata` errors for `cmd` / root were environment-only — clean on CI)
- [x] `make e2e` — verified green via CI (both `ubuntu-24.04` and `macos-15`); locally blocked because Playwright config pins `channel: "chrome"`, system Chrome was unavailable, and the network policy refused both `playwright install chrome` and `playwright install chromium`.
