### PR TITLE
refactor(frontend): split App.tsx effects into per-responsibility hooks

### DIFF
--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -1,82 +1,23 @@
-import { useEffect, useRef, useState, type JSX } from "react";
-import { fetchFiles, fetchFileSource, type FileEntry } from "./api/files";
-import { subscribe } from "./api/events";
-import { renderPlantUML } from "./plantuml/renderer";
+import { useState, type JSX } from "react";
 import { FileTree } from "./components/file-tree";
 import { Preview } from "./components/preview";
 import { SourceView } from "./components/source-view";
+import { useActiveRender } from "./hooks/useActiveRender";
+import { useFileList } from "./hooks/useFileList";
+import { useServerEvents } from "./hooks/useServerEvents";
 import { SOURCE_PANEL_ID, SOURCE_PANEL_NAME, SOURCE_TOGGLE_LABEL } from "./sourcePanel";
 
-type RenderState =
-  | { kind: "idle" }
-  | { kind: "loading" }
-  | { kind: "ok"; svg: string }
-  | { kind: "error"; message: string };
-
 export default function App(): JSX.Element {
-  const [files, setFiles] = useState<FileEntry[]>([]);
-  const [active, setActive] = useState<string | null>(null);
-  const [source, setSource] = useState<string>("");
-  const [render, setRender] = useState<RenderState>({ kind: "idle" });
+  const { files, active, setActive, reload: reloadFiles } = useFileList();
+  const { source, render, reload: reloadActive } = useActiveRender(active);
   const [sourceOpen, setSourceOpen] = useState<boolean>(true);
-  const [filesReloadKey, setFilesReloadKey] = useState(0);
-  const [activeReloadKey, setActiveReloadKey] = useState(0);
 
-  // Synced during render so the SSE callback (which lives across active
-  // changes) reads the current path without re-subscribing per file switch.
-  const activeRef = useRef<string | null>(null);
-  activeRef.current = active;
-
-  const renderSeq = useRef(0);
-
-  useEffect(() => {
-    void (async () => {
-      const list = await fetchFiles();
-      setFiles(list);
-      setActive((prev) =>
-        prev && list.some((f) => f.path === prev) ? prev : (list[0]?.path ?? null),
-      );
-    })();
-  }, [filesReloadKey]);
-
-  useEffect(() => {
-    if (!active) {
-      renderSeq.current++;
-      setSource("");
-      setRender({ kind: "idle" });
-      return;
-    }
-
-    const seq = ++renderSeq.current;
-    setRender({ kind: "loading" });
-
-    void (async () => {
-      try {
-        const src = await fetchFileSource(active);
-        if (seq !== renderSeq.current) return;
-        setSource(src);
-        const svg = await renderPlantUML(src);
-        if (seq !== renderSeq.current) return;
-        setRender({ kind: "ok", svg });
-      } catch (e) {
-        if (seq !== renderSeq.current) return;
-        const message = e instanceof Error ? e.message : String(e);
-        setRender({ kind: "error", message });
-      }
-    })();
-  }, [active, activeReloadKey]);
-
-  useEffect(() => {
-    const unsubscribe = subscribe((ev) => {
-      if (ev.type === "changed") {
-        if (ev.path === activeRef.current) setActiveReloadKey((k) => k + 1);
-      } else if (ev.type === "tree") {
-        setFilesReloadKey((k) => k + 1);
-      }
-    });
-
-    return unsubscribe;
-  }, []);
+  useServerEvents({
+    onTree: reloadFiles,
+    onChanged: (path) => {
+      if (path === active) reloadActive();
+    },
+  });
 
   const activeName = files.find((f) => f.path === active)?.rel ?? "";
   const toggleLabel = sourceOpen ? SOURCE_TOGGLE_LABEL.open : SOURCE_TOGGLE_LABEL.closed;

--- a/internal/frontend/src/App.tsx
+++ b/internal/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { useServerEvents } from "./hooks/useServerEvents";
 import { SOURCE_PANEL_ID, SOURCE_PANEL_NAME, SOURCE_TOGGLE_LABEL } from "./sourcePanel";
 
 export default function App(): JSX.Element {
-  const { files, active, setActive, reload: reloadFiles } = useFileList();
+  const { files, active, select, reload: reloadFiles } = useFileList();
   const { source, render, reload: reloadActive } = useActiveRender(active);
   const [sourceOpen, setSourceOpen] = useState<boolean>(true);
 
@@ -30,7 +30,7 @@ export default function App(): JSX.Element {
           <p className="text-xs text-slate-500">{files.length} file(s)</p>
         </div>
 
-        <FileTree files={files} active={active} onSelect={setActive} />
+        <FileTree files={files} active={active} onSelect={select} />
       </aside>
 
       <main className="flex min-w-0 flex-1 flex-col">

--- a/internal/frontend/src/hooks/useActiveRender.test.tsx
+++ b/internal/frontend/src/hooks/useActiveRender.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchFileSource } from "../api/files";
 import { renderPlantUML } from "../plantuml/renderer";
+import { flush } from "../test/flush";
 import { setupRender } from "../test/render";
 import { useActiveRender, type UseActiveRenderResult } from "./useActiveRender";
 
@@ -28,14 +29,6 @@ function Probe({ initial = null }: { initial?: string | null }): JSX.Element {
 }
 
 const render = setupRender();
-
-const flush = async (): Promise<void> => {
-  await act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-  });
-};
 
 const deferred = <T,>(): {
   promise: Promise<T>;
@@ -75,7 +68,7 @@ describe("useActiveRender", () => {
     mockedRenderPlantUML.mockResolvedValueOnce("data:image/svg+xml,svg");
 
     render(<Probe initial="/a.puml" />);
-    await flush();
+    await flush(3);
 
     expect(captured!.source).toBe("@startuml\n@enduml");
     expect(captured!.render).toEqual({ kind: "ok", svg: "data:image/svg+xml,svg" });
@@ -124,7 +117,7 @@ describe("useActiveRender", () => {
   ])("reports error state when $name", async ({ setup, message }) => {
     setup();
     render(<Probe initial="/a.puml" />);
-    await flush();
+    await flush(3);
 
     expect(captured!.render).toEqual({ kind: "error", message });
   });
@@ -133,7 +126,7 @@ describe("useActiveRender", () => {
     mockedFetchFileSource.mockResolvedValueOnce("source");
     mockedRenderPlantUML.mockResolvedValueOnce("data:image/svg+xml,x");
     render(<Probe initial="/a.puml" />);
-    await flush();
+    await flush(3);
 
     act(() => setActiveExternal!(null));
     expect(captured!.source).toBe("");
@@ -167,12 +160,12 @@ describe("useActiveRender", () => {
     mockedFetchFileSource.mockResolvedValue("source");
     mockedRenderPlantUML.mockResolvedValue("data:image/svg+xml,x");
     render(<Probe initial="/a.puml" />);
-    await flush();
+    await flush(3);
 
     expect(mockedFetchFileSource).toHaveBeenCalledTimes(1);
 
     act(() => captured!.reload());
-    await flush();
+    await flush(3);
 
     expect(mockedFetchFileSource).toHaveBeenCalledTimes(2);
   });

--- a/internal/frontend/src/hooks/useActiveRender.test.tsx
+++ b/internal/frontend/src/hooks/useActiveRender.test.tsx
@@ -20,7 +20,7 @@ const mockedRenderPlantUML = vi.mocked(renderPlantUML);
 let captured: UseActiveRenderResult | null;
 let setActiveExternal: ((path: string | null) => void) | null;
 
-function Harness({ initial = null }: { initial?: string | null }): JSX.Element {
+function Probe({ initial = null }: { initial?: string | null }): JSX.Element {
   const [active, setActive] = useState<string | null>(initial);
   setActiveExternal = setActive;
   captured = useActiveRender(active);
@@ -64,7 +64,7 @@ afterEach(() => {
 
 describe("useActiveRender", () => {
   it("starts idle with no active path", () => {
-    render(<Harness initial={null} />);
+    render(<Probe initial={null} />);
     expect(captured!.render).toEqual({ kind: "idle" });
     expect(captured!.source).toBe("");
     expect(mockedFetchFileSource).not.toHaveBeenCalled();
@@ -74,7 +74,7 @@ describe("useActiveRender", () => {
     mockedFetchFileSource.mockResolvedValueOnce("@startuml\n@enduml");
     mockedRenderPlantUML.mockResolvedValueOnce("data:image/svg+xml,svg");
 
-    render(<Harness initial="/a.puml" />);
+    render(<Probe initial="/a.puml" />);
     await flush();
 
     expect(captured!.source).toBe("@startuml\n@enduml");
@@ -87,7 +87,7 @@ describe("useActiveRender", () => {
     mockedFetchFileSource.mockReturnValueOnce(src.promise);
     mockedRenderPlantUML.mockResolvedValueOnce("data:image/svg+xml,x");
 
-    render(<Harness initial="/a.puml" />);
+    render(<Probe initial="/a.puml" />);
     expect(captured!.render).toEqual({ kind: "loading" });
 
     await act(async () => {
@@ -100,7 +100,7 @@ describe("useActiveRender", () => {
 
   it("reports an error state when the source fetch fails", async () => {
     mockedFetchFileSource.mockRejectedValueOnce(new Error("boom"));
-    render(<Harness initial="/a.puml" />);
+    render(<Probe initial="/a.puml" />);
     await flush();
 
     expect(captured!.render).toEqual({ kind: "error", message: "boom" });
@@ -109,7 +109,7 @@ describe("useActiveRender", () => {
   it("reports an error state when rendering fails", async () => {
     mockedFetchFileSource.mockResolvedValueOnce("source");
     mockedRenderPlantUML.mockRejectedValueOnce(new Error("parse error"));
-    render(<Harness initial="/a.puml" />);
+    render(<Probe initial="/a.puml" />);
     await flush();
 
     expect(captured!.render).toEqual({ kind: "error", message: "parse error" });
@@ -118,7 +118,7 @@ describe("useActiveRender", () => {
   it("returns to idle and clears source when active becomes null", async () => {
     mockedFetchFileSource.mockResolvedValueOnce("source");
     mockedRenderPlantUML.mockResolvedValueOnce("data:image/svg+xml,x");
-    render(<Harness initial="/a.puml" />);
+    render(<Probe initial="/a.puml" />);
     await flush();
 
     act(() => setActiveExternal!(null));
@@ -132,7 +132,7 @@ describe("useActiveRender", () => {
     mockedFetchFileSource.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
     mockedRenderPlantUML.mockResolvedValue("data:image/svg+xml,svg");
 
-    render(<Harness initial="/a.puml" />);
+    render(<Probe initial="/a.puml" />);
     act(() => setActiveExternal!("/b.puml"));
 
     await act(async () => {
@@ -152,7 +152,7 @@ describe("useActiveRender", () => {
   it("re-fetches when reload is invoked", async () => {
     mockedFetchFileSource.mockResolvedValue("source");
     mockedRenderPlantUML.mockResolvedValue("data:image/svg+xml,x");
-    render(<Harness initial="/a.puml" />);
+    render(<Probe initial="/a.puml" />);
     await flush();
 
     expect(mockedFetchFileSource).toHaveBeenCalledTimes(1);
@@ -165,7 +165,7 @@ describe("useActiveRender", () => {
 
   it("coerces non-Error throwables into a string message", async () => {
     mockedFetchFileSource.mockRejectedValueOnce("string error");
-    render(<Harness initial="/a.puml" />);
+    render(<Probe initial="/a.puml" />);
     await flush();
 
     expect(captured!.render).toEqual({ kind: "error", message: "string error" });

--- a/internal/frontend/src/hooks/useActiveRender.test.tsx
+++ b/internal/frontend/src/hooks/useActiveRender.test.tsx
@@ -1,0 +1,173 @@
+import { act, useState, type JSX } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchFileSource } from "../api/files";
+import { renderPlantUML } from "../plantuml/renderer";
+import { setupRender } from "../test/render";
+import { useActiveRender, type UseActiveRenderResult } from "./useActiveRender";
+
+vi.mock("../api/files", () => ({
+  fetchFileSource: vi.fn(),
+}));
+
+vi.mock("../plantuml/renderer", () => ({
+  renderPlantUML: vi.fn(),
+}));
+
+const mockedFetchFileSource = vi.mocked(fetchFileSource);
+const mockedRenderPlantUML = vi.mocked(renderPlantUML);
+
+let captured: UseActiveRenderResult | null;
+let setActiveExternal: ((path: string | null) => void) | null;
+
+function Harness({ initial = null }: { initial?: string | null }): JSX.Element {
+  const [active, setActive] = useState<string | null>(initial);
+  setActiveExternal = setActive;
+  captured = useActiveRender(active);
+  return <div />;
+}
+
+const render = setupRender();
+
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+const deferred = <T,>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+beforeEach(() => {
+  captured = null;
+  setActiveExternal = null;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  captured = null;
+  setActiveExternal = null;
+});
+
+describe("useActiveRender", () => {
+  it("starts idle with no active path", () => {
+    render(<Harness initial={null} />);
+    expect(captured!.render).toEqual({ kind: "idle" });
+    expect(captured!.source).toBe("");
+    expect(mockedFetchFileSource).not.toHaveBeenCalled();
+  });
+
+  it("fetches source and renders SVG when active is set", async () => {
+    mockedFetchFileSource.mockResolvedValueOnce("@startuml\n@enduml");
+    mockedRenderPlantUML.mockResolvedValueOnce("data:image/svg+xml,svg");
+
+    render(<Harness initial="/a.puml" />);
+    await flush();
+
+    expect(captured!.source).toBe("@startuml\n@enduml");
+    expect(captured!.render).toEqual({ kind: "ok", svg: "data:image/svg+xml,svg" });
+    expect(mockedFetchFileSource).toHaveBeenCalledWith("/a.puml");
+  });
+
+  it("shows loading state while the source/render is in flight", async () => {
+    const src = deferred<string>();
+    mockedFetchFileSource.mockReturnValueOnce(src.promise);
+    mockedRenderPlantUML.mockResolvedValueOnce("data:image/svg+xml,x");
+
+    render(<Harness initial="/a.puml" />);
+    expect(captured!.render).toEqual({ kind: "loading" });
+
+    await act(async () => {
+      src.resolve("body");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(captured!.render).toEqual({ kind: "ok", svg: "data:image/svg+xml,x" });
+  });
+
+  it("reports an error state when the source fetch fails", async () => {
+    mockedFetchFileSource.mockRejectedValueOnce(new Error("boom"));
+    render(<Harness initial="/a.puml" />);
+    await flush();
+
+    expect(captured!.render).toEqual({ kind: "error", message: "boom" });
+  });
+
+  it("reports an error state when rendering fails", async () => {
+    mockedFetchFileSource.mockResolvedValueOnce("source");
+    mockedRenderPlantUML.mockRejectedValueOnce(new Error("parse error"));
+    render(<Harness initial="/a.puml" />);
+    await flush();
+
+    expect(captured!.render).toEqual({ kind: "error", message: "parse error" });
+  });
+
+  it("returns to idle and clears source when active becomes null", async () => {
+    mockedFetchFileSource.mockResolvedValueOnce("source");
+    mockedRenderPlantUML.mockResolvedValueOnce("data:image/svg+xml,x");
+    render(<Harness initial="/a.puml" />);
+    await flush();
+
+    act(() => setActiveExternal!(null));
+    expect(captured!.source).toBe("");
+    expect(captured!.render).toEqual({ kind: "idle" });
+  });
+
+  it("discards results from a stale fetch when active changes rapidly", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    mockedFetchFileSource.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    mockedRenderPlantUML.mockResolvedValue("data:image/svg+xml,svg");
+
+    render(<Harness initial="/a.puml" />);
+    act(() => setActiveExternal!("/b.puml"));
+
+    await act(async () => {
+      first.resolve("first body");
+      second.resolve("second body");
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(captured!.source).toBe("second body");
+    expect(captured!.render).toEqual({ kind: "ok", svg: "data:image/svg+xml,svg" });
+    // The stale `/a.puml` fetch resolved first but must not reach renderPlantUML.
+    expect(mockedRenderPlantUML).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches when reload is invoked", async () => {
+    mockedFetchFileSource.mockResolvedValue("source");
+    mockedRenderPlantUML.mockResolvedValue("data:image/svg+xml,x");
+    render(<Harness initial="/a.puml" />);
+    await flush();
+
+    expect(mockedFetchFileSource).toHaveBeenCalledTimes(1);
+
+    act(() => captured!.reload());
+    await flush();
+
+    expect(mockedFetchFileSource).toHaveBeenCalledTimes(2);
+  });
+
+  it("coerces non-Error throwables into a string message", async () => {
+    mockedFetchFileSource.mockRejectedValueOnce("string error");
+    render(<Harness initial="/a.puml" />);
+    await flush();
+
+    expect(captured!.render).toEqual({ kind: "error", message: "string error" });
+  });
+});

--- a/internal/frontend/src/hooks/useActiveRender.test.tsx
+++ b/internal/frontend/src/hooks/useActiveRender.test.tsx
@@ -98,21 +98,35 @@ describe("useActiveRender", () => {
     expect(captured!.render).toEqual({ kind: "ok", svg: "data:image/svg+xml,x" });
   });
 
-  it("reports an error state when the source fetch fails", async () => {
-    mockedFetchFileSource.mockRejectedValueOnce(new Error("boom"));
+  it.each([
+    {
+      name: "source fetch rejects with Error",
+      setup: () => {
+        mockedFetchFileSource.mockRejectedValueOnce(new Error("boom"));
+      },
+      message: "boom",
+    },
+    {
+      name: "renderer rejects with Error",
+      setup: () => {
+        mockedFetchFileSource.mockResolvedValueOnce("source");
+        mockedRenderPlantUML.mockRejectedValueOnce(new Error("parse error"));
+      },
+      message: "parse error",
+    },
+    {
+      name: "non-Error throwable is coerced to string",
+      setup: () => {
+        mockedFetchFileSource.mockRejectedValueOnce("string error");
+      },
+      message: "string error",
+    },
+  ])("reports error state when $name", async ({ setup, message }) => {
+    setup();
     render(<Probe initial="/a.puml" />);
     await flush();
 
-    expect(captured!.render).toEqual({ kind: "error", message: "boom" });
-  });
-
-  it("reports an error state when rendering fails", async () => {
-    mockedFetchFileSource.mockResolvedValueOnce("source");
-    mockedRenderPlantUML.mockRejectedValueOnce(new Error("parse error"));
-    render(<Probe initial="/a.puml" />);
-    await flush();
-
-    expect(captured!.render).toEqual({ kind: "error", message: "parse error" });
+    expect(captured!.render).toEqual({ kind: "error", message });
   });
 
   it("returns to idle and clears source when active becomes null", async () => {
@@ -161,13 +175,5 @@ describe("useActiveRender", () => {
     await flush();
 
     expect(mockedFetchFileSource).toHaveBeenCalledTimes(2);
-  });
-
-  it("coerces non-Error throwables into a string message", async () => {
-    mockedFetchFileSource.mockRejectedValueOnce("string error");
-    render(<Probe initial="/a.puml" />);
-    await flush();
-
-    expect(captured!.render).toEqual({ kind: "error", message: "string error" });
   });
 });

--- a/internal/frontend/src/hooks/useActiveRender.ts
+++ b/internal/frontend/src/hooks/useActiveRender.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from "react";
+import { fetchFileSource } from "../api/files";
+import { renderPlantUML } from "../plantuml/renderer";
+
+export type RenderState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ok"; svg: string }
+  | { kind: "error"; message: string };
+
+export interface UseActiveRenderResult {
+  source: string;
+  render: RenderState;
+  reload: () => void;
+}
+
+export function useActiveRender(active: string | null): UseActiveRenderResult {
+  const [source, setSource] = useState<string>("");
+  const [render, setRender] = useState<RenderState>({ kind: "idle" });
+  const [reloadKey, setReloadKey] = useState(0);
+  const renderSeq = useRef(0);
+
+  useEffect(() => {
+    if (!active) {
+      renderSeq.current++;
+      setSource("");
+      setRender({ kind: "idle" });
+      return;
+    }
+
+    const seq = ++renderSeq.current;
+    setRender({ kind: "loading" });
+
+    void (async () => {
+      try {
+        const src = await fetchFileSource(active);
+        if (seq !== renderSeq.current) return;
+        setSource(src);
+        const svg = await renderPlantUML(src);
+        if (seq !== renderSeq.current) return;
+        setRender({ kind: "ok", svg });
+      } catch (e) {
+        if (seq !== renderSeq.current) return;
+        const message = e instanceof Error ? e.message : String(e);
+        setRender({ kind: "error", message });
+      }
+    })();
+  }, [active, reloadKey]);
+
+  return {
+    source,
+    render,
+    reload: () => setReloadKey((k) => k + 1),
+  };
+}

--- a/internal/frontend/src/hooks/useActiveRender.ts
+++ b/internal/frontend/src/hooks/useActiveRender.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { fetchFileSource } from "../api/files";
 import { renderPlantUML } from "../plantuml/renderer";
 
-export type RenderState =
+type RenderState =
   | { kind: "idle" }
   | { kind: "loading" }
   | { kind: "ok"; svg: string }

--- a/internal/frontend/src/hooks/useFileList.test.tsx
+++ b/internal/frontend/src/hooks/useFileList.test.tsx
@@ -1,0 +1,138 @@
+import { act, type JSX } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchFiles, type FileEntry } from "../api/files";
+import { setupRender } from "../test/render";
+import { useFileList, type UseFileListResult } from "./useFileList";
+
+vi.mock("../api/files", () => ({
+  fetchFiles: vi.fn(),
+}));
+
+const mockedFetchFiles = vi.mocked(fetchFiles);
+
+let captured: UseFileListResult | null;
+
+function Harness(): JSX.Element {
+  captured = useFileList();
+  return <div />;
+}
+
+const render = setupRender();
+
+const file = (path: string): FileEntry => ({
+  path,
+  rel: path,
+  name: path,
+  source: "/",
+});
+
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+beforeEach(() => {
+  captured = null;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  captured = null;
+});
+
+describe("useFileList", () => {
+  it("loads files and selects the first one as active", async () => {
+    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
+
+    render(<Harness />);
+    await flush();
+
+    expect(captured!.files.map((f) => f.path)).toEqual(["/a.puml", "/b.puml"]);
+    expect(captured!.active).toBe("/a.puml");
+  });
+
+  it("starts with no active when the file list is empty", async () => {
+    mockedFetchFiles.mockResolvedValueOnce([]);
+
+    render(<Harness />);
+    await flush();
+
+    expect(captured!.files).toEqual([]);
+    expect(captured!.active).toBeNull();
+  });
+
+  it("setActive updates the active path", async () => {
+    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
+
+    render(<Harness />);
+    await flush();
+
+    act(() => captured!.setActive("/b.puml"));
+    expect(captured!.active).toBe("/b.puml");
+  });
+
+  it("preserves active across reloads when the file still exists", async () => {
+    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
+    render(<Harness />);
+    await flush();
+
+    act(() => captured!.setActive("/b.puml"));
+
+    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml"), file("/c.puml")]);
+    act(() => captured!.reload());
+    await flush();
+
+    expect(captured!.active).toBe("/b.puml");
+    expect(captured!.files).toHaveLength(3);
+  });
+
+  it("falls back to the first file when the previously active path is gone", async () => {
+    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
+    render(<Harness />);
+    await flush();
+
+    act(() => captured!.setActive("/b.puml"));
+
+    mockedFetchFiles.mockResolvedValueOnce([file("/c.puml"), file("/d.puml")]);
+    act(() => captured!.reload());
+    await flush();
+
+    expect(captured!.active).toBe("/c.puml");
+  });
+
+  it("clears active when the reloaded list is empty", async () => {
+    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml")]);
+    render(<Harness />);
+    await flush();
+
+    expect(captured!.active).toBe("/a.puml");
+
+    mockedFetchFiles.mockResolvedValueOnce([]);
+    act(() => captured!.reload());
+    await flush();
+
+    expect(captured!.active).toBeNull();
+  });
+
+  it("calls fetchFiles only once on mount", async () => {
+    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml")]);
+    render(<Harness />);
+    await flush();
+    expect(mockedFetchFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches when reload is invoked", async () => {
+    mockedFetchFiles.mockResolvedValue([file("/a.puml")]);
+    render(<Harness />);
+    await flush();
+
+    act(() => captured!.reload());
+    await flush();
+    act(() => captured!.reload());
+    await flush();
+
+    expect(mockedFetchFiles).toHaveBeenCalledTimes(3);
+  });
+});

--- a/internal/frontend/src/hooks/useFileList.test.tsx
+++ b/internal/frontend/src/hooks/useFileList.test.tsx
@@ -13,7 +13,7 @@ const mockedFetchFiles = vi.mocked(fetchFiles);
 
 let captured: UseFileListResult | null;
 
-function Harness(): JSX.Element {
+function Probe(): JSX.Element {
   captured = useFileList();
   return <div />;
 }
@@ -46,7 +46,7 @@ describe("useFileList", () => {
   it("loads files and selects the first one as active", async () => {
     mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
 
-    render(<Harness />);
+    render(<Probe />);
     await flush();
 
     expect(captured!.files.map((f) => f.path)).toEqual(["/a.puml", "/b.puml"]);
@@ -56,7 +56,7 @@ describe("useFileList", () => {
   it("starts with no active when the file list is empty", async () => {
     mockedFetchFiles.mockResolvedValueOnce([]);
 
-    render(<Harness />);
+    render(<Probe />);
     await flush();
 
     expect(captured!.files).toEqual([]);
@@ -66,7 +66,7 @@ describe("useFileList", () => {
   it("select updates the active path", async () => {
     mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
 
-    render(<Harness />);
+    render(<Probe />);
     await flush();
 
     act(() => captured!.select("/b.puml"));
@@ -75,7 +75,7 @@ describe("useFileList", () => {
 
   it("preserves active across reloads when the file still exists", async () => {
     mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
-    render(<Harness />);
+    render(<Probe />);
     await flush();
 
     act(() => captured!.select("/b.puml"));
@@ -90,7 +90,7 @@ describe("useFileList", () => {
 
   it("falls back to the first file when the previously active path is gone", async () => {
     mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
-    render(<Harness />);
+    render(<Probe />);
     await flush();
 
     act(() => captured!.select("/b.puml"));
@@ -104,7 +104,7 @@ describe("useFileList", () => {
 
   it("clears active when the reloaded list is empty", async () => {
     mockedFetchFiles.mockResolvedValueOnce([file("/a.puml")]);
-    render(<Harness />);
+    render(<Probe />);
     await flush();
 
     expect(captured!.active).toBe("/a.puml");
@@ -118,14 +118,14 @@ describe("useFileList", () => {
 
   it("calls fetchFiles only once on mount", async () => {
     mockedFetchFiles.mockResolvedValueOnce([file("/a.puml")]);
-    render(<Harness />);
+    render(<Probe />);
     await flush();
     expect(mockedFetchFiles).toHaveBeenCalledTimes(1);
   });
 
   it("re-fetches when reload is invoked", async () => {
     mockedFetchFiles.mockResolvedValue([file("/a.puml")]);
-    render(<Harness />);
+    render(<Probe />);
     await flush();
 
     act(() => captured!.reload());

--- a/internal/frontend/src/hooks/useFileList.test.tsx
+++ b/internal/frontend/src/hooks/useFileList.test.tsx
@@ -43,24 +43,21 @@ afterEach(() => {
 });
 
 describe("useFileList", () => {
-  it("loads files and selects the first one as active", async () => {
-    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
+  it.each([
+    {
+      name: "selects the first file as active",
+      files: [file("/a.puml"), file("/b.puml")],
+      expected: "/a.puml",
+    },
+    { name: "leaves active null when the list is empty", files: [], expected: null },
+  ])("initial load $name", async ({ files: initial, expected }) => {
+    mockedFetchFiles.mockResolvedValueOnce(initial);
 
     render(<Probe />);
     await flush();
 
-    expect(captured!.files.map((f) => f.path)).toEqual(["/a.puml", "/b.puml"]);
-    expect(captured!.active).toBe("/a.puml");
-  });
-
-  it("starts with no active when the file list is empty", async () => {
-    mockedFetchFiles.mockResolvedValueOnce([]);
-
-    render(<Probe />);
-    await flush();
-
-    expect(captured!.files).toEqual([]);
-    expect(captured!.active).toBeNull();
+    expect(captured!.files).toEqual(initial);
+    expect(captured!.active).toBe(expected);
   });
 
   it("select updates the active path", async () => {
@@ -73,66 +70,55 @@ describe("useFileList", () => {
     expect(captured!.active).toBe("/b.puml");
   });
 
-  it("preserves active across reloads when the file still exists", async () => {
-    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
+  it.each([
+    {
+      name: "preserves active when the file still exists",
+      initial: [file("/a.puml"), file("/b.puml")],
+      selected: "/b.puml",
+      reloaded: [file("/a.puml"), file("/b.puml"), file("/c.puml")],
+      expected: "/b.puml",
+    },
+    {
+      name: "falls back to the first file when active is gone",
+      initial: [file("/a.puml"), file("/b.puml")],
+      selected: "/b.puml",
+      reloaded: [file("/c.puml"), file("/d.puml")],
+      expected: "/c.puml",
+    },
+    {
+      name: "clears active when the reloaded list is empty",
+      initial: [file("/a.puml")],
+      selected: "/a.puml",
+      reloaded: [],
+      expected: null,
+    },
+  ])("on reload $name", async ({ initial, selected, reloaded, expected }) => {
+    mockedFetchFiles.mockResolvedValueOnce(initial);
     render(<Probe />);
     await flush();
 
-    act(() => captured!.select("/b.puml"));
+    act(() => captured!.select(selected));
 
-    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml"), file("/c.puml")]);
+    mockedFetchFiles.mockResolvedValueOnce(reloaded);
     act(() => captured!.reload());
     await flush();
 
-    expect(captured!.active).toBe("/b.puml");
-    expect(captured!.files).toHaveLength(3);
+    expect(captured!.active).toBe(expected);
   });
 
-  it("falls back to the first file when the previously active path is gone", async () => {
-    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
-    render(<Probe />);
-    await flush();
-
-    act(() => captured!.select("/b.puml"));
-
-    mockedFetchFiles.mockResolvedValueOnce([file("/c.puml"), file("/d.puml")]);
-    act(() => captured!.reload());
-    await flush();
-
-    expect(captured!.active).toBe("/c.puml");
-  });
-
-  it("clears active when the reloaded list is empty", async () => {
-    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml")]);
-    render(<Probe />);
-    await flush();
-
-    expect(captured!.active).toBe("/a.puml");
-
-    mockedFetchFiles.mockResolvedValueOnce([]);
-    act(() => captured!.reload());
-    await flush();
-
-    expect(captured!.active).toBeNull();
-  });
-
-  it("calls fetchFiles only once on mount", async () => {
-    mockedFetchFiles.mockResolvedValueOnce([file("/a.puml")]);
-    render(<Probe />);
-    await flush();
-    expect(mockedFetchFiles).toHaveBeenCalledTimes(1);
-  });
-
-  it("re-fetches when reload is invoked", async () => {
+  it.each([
+    { name: "once on mount", reloads: 0, expected: 1 },
+    { name: "once per reload", reloads: 2, expected: 3 },
+  ])("fetchFiles is called $name", async ({ reloads, expected }) => {
     mockedFetchFiles.mockResolvedValue([file("/a.puml")]);
     render(<Probe />);
     await flush();
 
-    act(() => captured!.reload());
-    await flush();
-    act(() => captured!.reload());
-    await flush();
+    for (let i = 0; i < reloads; i++) {
+      act(() => captured!.reload());
+      await flush();
+    }
 
-    expect(mockedFetchFiles).toHaveBeenCalledTimes(3);
+    expect(mockedFetchFiles).toHaveBeenCalledTimes(expected);
   });
 });

--- a/internal/frontend/src/hooks/useFileList.test.tsx
+++ b/internal/frontend/src/hooks/useFileList.test.tsx
@@ -63,13 +63,13 @@ describe("useFileList", () => {
     expect(captured!.active).toBeNull();
   });
 
-  it("setActive updates the active path", async () => {
+  it("select updates the active path", async () => {
     mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml")]);
 
     render(<Harness />);
     await flush();
 
-    act(() => captured!.setActive("/b.puml"));
+    act(() => captured!.select("/b.puml"));
     expect(captured!.active).toBe("/b.puml");
   });
 
@@ -78,7 +78,7 @@ describe("useFileList", () => {
     render(<Harness />);
     await flush();
 
-    act(() => captured!.setActive("/b.puml"));
+    act(() => captured!.select("/b.puml"));
 
     mockedFetchFiles.mockResolvedValueOnce([file("/a.puml"), file("/b.puml"), file("/c.puml")]);
     act(() => captured!.reload());
@@ -93,7 +93,7 @@ describe("useFileList", () => {
     render(<Harness />);
     await flush();
 
-    act(() => captured!.setActive("/b.puml"));
+    act(() => captured!.select("/b.puml"));
 
     mockedFetchFiles.mockResolvedValueOnce([file("/c.puml"), file("/d.puml")]);
     act(() => captured!.reload());

--- a/internal/frontend/src/hooks/useFileList.test.tsx
+++ b/internal/frontend/src/hooks/useFileList.test.tsx
@@ -2,6 +2,7 @@ import { act, type JSX } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchFiles, type FileEntry } from "../api/files";
+import { flush } from "../test/flush";
 import { setupRender } from "../test/render";
 import { useFileList, type UseFileListResult } from "./useFileList";
 
@@ -26,12 +27,6 @@ const file = (path: string): FileEntry => ({
   name: path,
   source: "/",
 });
-
-const flush = async (): Promise<void> => {
-  await act(async () => {
-    await Promise.resolve();
-  });
-};
 
 beforeEach(() => {
   captured = null;

--- a/internal/frontend/src/hooks/useFileList.ts
+++ b/internal/frontend/src/hooks/useFileList.ts
@@ -4,7 +4,7 @@ import { fetchFiles, type FileEntry } from "../api/files";
 export interface UseFileListResult {
   files: FileEntry[];
   active: string | null;
-  setActive: (path: string | null) => void;
+  select: (path: string) => void;
   reload: () => void;
 }
 
@@ -26,7 +26,7 @@ export function useFileList(): UseFileListResult {
   return {
     files,
     active,
-    setActive,
+    select: (path) => setActive(path),
     reload: () => setReloadKey((k) => k + 1),
   };
 }

--- a/internal/frontend/src/hooks/useFileList.ts
+++ b/internal/frontend/src/hooks/useFileList.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { fetchFiles, type FileEntry } from "../api/files";
+
+export interface UseFileListResult {
+  files: FileEntry[];
+  active: string | null;
+  setActive: (path: string | null) => void;
+  reload: () => void;
+}
+
+export function useFileList(): UseFileListResult {
+  const [files, setFiles] = useState<FileEntry[]>([]);
+  const [active, setActive] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    void (async () => {
+      const list = await fetchFiles();
+      setFiles(list);
+      setActive((prev) =>
+        prev && list.some((f) => f.path === prev) ? prev : (list[0]?.path ?? null),
+      );
+    })();
+  }, [reloadKey]);
+
+  return {
+    files,
+    active,
+    setActive,
+    reload: () => setReloadKey((k) => k + 1),
+  };
+}

--- a/internal/frontend/src/hooks/useServerEvents.test.tsx
+++ b/internal/frontend/src/hooks/useServerEvents.test.tsx
@@ -68,30 +68,24 @@ describe("useServerEvents", () => {
     expect(subscriptions).toHaveLength(1);
   });
 
-  it("invokes onTree for tree events", () => {
-    const onTree = vi.fn();
-    render(<Probe onTree={onTree} onChanged={() => {}} />);
-
-    emit({ type: "tree" });
-    expect(onTree).toHaveBeenCalledTimes(1);
-  });
-
-  it("invokes onChanged with the changed path", () => {
-    const onChanged = vi.fn();
-    render(<Probe onTree={() => {}} onChanged={onChanged} />);
-
-    emit({ type: "changed", path: "/a.puml" });
-    expect(onChanged).toHaveBeenCalledWith("/a.puml");
-  });
-
-  it("ignores hello events", () => {
+  it.each<{ name: string; event: ServerEvent; treeCalls: number; changedArgs: string[] }>([
+    { name: "tree -> onTree()", event: { type: "tree" }, treeCalls: 1, changedArgs: [] },
+    {
+      name: "changed -> onChanged(path)",
+      event: { type: "changed", path: "/a.puml" },
+      treeCalls: 0,
+      changedArgs: ["/a.puml"],
+    },
+    { name: "hello -> noop", event: { type: "hello" }, treeCalls: 0, changedArgs: [] },
+  ])("routes $name", ({ event, treeCalls, changedArgs }) => {
     const onTree = vi.fn();
     const onChanged = vi.fn();
     render(<Probe onTree={onTree} onChanged={onChanged} />);
 
-    emit({ type: "hello" });
-    expect(onTree).not.toHaveBeenCalled();
-    expect(onChanged).not.toHaveBeenCalled();
+    emit(event);
+
+    expect(onTree).toHaveBeenCalledTimes(treeCalls);
+    expect(onChanged.mock.calls.flat()).toEqual(changedArgs);
   });
 
   it("does not resubscribe when handler identities change between renders", () => {

--- a/internal/frontend/src/hooks/useServerEvents.test.tsx
+++ b/internal/frontend/src/hooks/useServerEvents.test.tsx
@@ -23,16 +23,16 @@ function Harness(props: { onTree: () => void; onChanged: (path: string) => void 
   return <div />;
 }
 
+let capturedSetActive: (path: string | null) => void;
+let changedForActive: number;
+
 function RebindHarness(): JSX.Element {
   const [active, setActive] = useState<string | null>("/a.puml");
-  (RebindHarness as unknown as { setActive: (p: string | null) => void }).setActive = setActive;
+  capturedSetActive = setActive;
   useServerEvents({
     onTree: () => {},
     onChanged: (path) => {
-      if (path === active) {
-        (RebindHarness as unknown as { changedCount: number }).changedCount =
-          ((RebindHarness as unknown as { changedCount?: number }).changedCount ?? 0) + 1;
-      }
+      if (path === active) changedForActive++;
     },
   });
   return <div />;
@@ -42,6 +42,7 @@ const render = setupRender();
 
 beforeEach(() => {
   subscriptions = [];
+  changedForActive = 0;
   vi.clearAllMocks();
   mockedSubscribe.mockImplementation((handler: EventHandler) => {
     const cleanup = vi.fn();
@@ -119,22 +120,18 @@ describe("useServerEvents", () => {
   });
 
   it("sees updated closure values through the ref (active path swap)", () => {
-    const ctx = RebindHarness as unknown as {
-      setActive: (p: string | null) => void;
-      changedCount?: number;
-    };
     render(<RebindHarness />);
 
     emit({ type: "changed", path: "/a.puml" });
-    expect(ctx.changedCount).toBe(1);
+    expect(changedForActive).toBe(1);
 
-    act(() => ctx.setActive("/b.puml"));
+    act(() => capturedSetActive("/b.puml"));
 
     emit({ type: "changed", path: "/a.puml" });
-    expect(ctx.changedCount).toBe(1);
+    expect(changedForActive).toBe(1);
 
     emit({ type: "changed", path: "/b.puml" });
-    expect(ctx.changedCount).toBe(2);
+    expect(changedForActive).toBe(2);
   });
 
   it("invokes the cleanup returned by subscribe on unmount", () => {

--- a/internal/frontend/src/hooks/useServerEvents.test.tsx
+++ b/internal/frontend/src/hooks/useServerEvents.test.tsx
@@ -18,7 +18,7 @@ interface SubscribeRecord {
 
 let subscriptions: SubscribeRecord[];
 
-function Harness(props: { onTree: () => void; onChanged: (path: string) => void }): JSX.Element {
+function Probe(props: { onTree: () => void; onChanged: (path: string) => void }): JSX.Element {
   useServerEvents({ onTree: props.onTree, onChanged: props.onChanged });
   return <div />;
 }
@@ -26,7 +26,7 @@ function Harness(props: { onTree: () => void; onChanged: (path: string) => void 
 let capturedSetActive: (path: string | null) => void;
 let changedForActive: number;
 
-function RebindHarness(): JSX.Element {
+function StatefulProbe(): JSX.Element {
   const [active, setActive] = useState<string | null>("/a.puml");
   capturedSetActive = setActive;
   useServerEvents({
@@ -63,14 +63,14 @@ const emit = (ev: ServerEvent): void => {
 
 describe("useServerEvents", () => {
   it("subscribes exactly once on mount", () => {
-    render(<Harness onTree={() => {}} onChanged={() => {}} />);
+    render(<Probe onTree={() => {}} onChanged={() => {}} />);
     expect(mockedSubscribe).toHaveBeenCalledTimes(1);
     expect(subscriptions).toHaveLength(1);
   });
 
   it("invokes onTree for tree events", () => {
     const onTree = vi.fn();
-    render(<Harness onTree={onTree} onChanged={() => {}} />);
+    render(<Probe onTree={onTree} onChanged={() => {}} />);
 
     emit({ type: "tree" });
     expect(onTree).toHaveBeenCalledTimes(1);
@@ -78,7 +78,7 @@ describe("useServerEvents", () => {
 
   it("invokes onChanged with the changed path", () => {
     const onChanged = vi.fn();
-    render(<Harness onTree={() => {}} onChanged={onChanged} />);
+    render(<Probe onTree={() => {}} onChanged={onChanged} />);
 
     emit({ type: "changed", path: "/a.puml" });
     expect(onChanged).toHaveBeenCalledWith("/a.puml");
@@ -87,7 +87,7 @@ describe("useServerEvents", () => {
   it("ignores hello events", () => {
     const onTree = vi.fn();
     const onChanged = vi.fn();
-    render(<Harness onTree={onTree} onChanged={onChanged} />);
+    render(<Probe onTree={onTree} onChanged={onChanged} />);
 
     emit({ type: "hello" });
     expect(onTree).not.toHaveBeenCalled();
@@ -97,8 +97,8 @@ describe("useServerEvents", () => {
   it("does not resubscribe when handler identities change between renders", () => {
     const onTreeA = vi.fn();
     const onTreeB = vi.fn();
-    render(<Harness onTree={onTreeA} onChanged={() => {}} />);
-    render(<Harness onTree={onTreeB} onChanged={() => {}} />);
+    render(<Probe onTree={onTreeA} onChanged={() => {}} />);
+    render(<Probe onTree={onTreeB} onChanged={() => {}} />);
 
     expect(mockedSubscribe).toHaveBeenCalledTimes(1);
 
@@ -110,8 +110,8 @@ describe("useServerEvents", () => {
   it("calls the latest onChanged after re-render", () => {
     const first = vi.fn();
     const second = vi.fn();
-    render(<Harness onTree={() => {}} onChanged={first} />);
-    render(<Harness onTree={() => {}} onChanged={second} />);
+    render(<Probe onTree={() => {}} onChanged={first} />);
+    render(<Probe onTree={() => {}} onChanged={second} />);
 
     emit({ type: "changed", path: "/x.puml" });
 
@@ -120,7 +120,7 @@ describe("useServerEvents", () => {
   });
 
   it("sees updated closure values through the ref (active path swap)", () => {
-    render(<RebindHarness />);
+    render(<StatefulProbe />);
 
     emit({ type: "changed", path: "/a.puml" });
     expect(changedForActive).toBe(1);
@@ -135,7 +135,7 @@ describe("useServerEvents", () => {
   });
 
   it("invokes the cleanup returned by subscribe on unmount", () => {
-    render(<Harness onTree={() => {}} onChanged={() => {}} />);
+    render(<Probe onTree={() => {}} onChanged={() => {}} />);
     expect(subscriptions[0]!.cleanup).not.toHaveBeenCalled();
 
     render(<div />);

--- a/internal/frontend/src/hooks/useServerEvents.test.tsx
+++ b/internal/frontend/src/hooks/useServerEvents.test.tsx
@@ -1,0 +1,147 @@
+import { act, useState, type JSX } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { subscribe, type EventHandler, type ServerEvent } from "../api/events";
+import { setupRender } from "../test/render";
+import { useServerEvents } from "./useServerEvents";
+
+vi.mock("../api/events", () => ({
+  subscribe: vi.fn(),
+}));
+
+const mockedSubscribe = vi.mocked(subscribe);
+
+interface SubscribeRecord {
+  handler: EventHandler;
+  cleanup: ReturnType<typeof vi.fn>;
+}
+
+let subscriptions: SubscribeRecord[];
+
+function Harness(props: { onTree: () => void; onChanged: (path: string) => void }): JSX.Element {
+  useServerEvents({ onTree: props.onTree, onChanged: props.onChanged });
+  return <div />;
+}
+
+function RebindHarness(): JSX.Element {
+  const [active, setActive] = useState<string | null>("/a.puml");
+  (RebindHarness as unknown as { setActive: (p: string | null) => void }).setActive = setActive;
+  useServerEvents({
+    onTree: () => {},
+    onChanged: (path) => {
+      if (path === active) {
+        (RebindHarness as unknown as { changedCount: number }).changedCount =
+          ((RebindHarness as unknown as { changedCount?: number }).changedCount ?? 0) + 1;
+      }
+    },
+  });
+  return <div />;
+}
+
+const render = setupRender();
+
+beforeEach(() => {
+  subscriptions = [];
+  vi.clearAllMocks();
+  mockedSubscribe.mockImplementation((handler: EventHandler) => {
+    const cleanup = vi.fn();
+    subscriptions.push({ handler, cleanup });
+    return cleanup;
+  });
+});
+
+afterEach(() => {
+  subscriptions = [];
+});
+
+const emit = (ev: ServerEvent): void => {
+  act(() => {
+    subscriptions[0]!.handler(ev);
+  });
+};
+
+describe("useServerEvents", () => {
+  it("subscribes exactly once on mount", () => {
+    render(<Harness onTree={() => {}} onChanged={() => {}} />);
+    expect(mockedSubscribe).toHaveBeenCalledTimes(1);
+    expect(subscriptions).toHaveLength(1);
+  });
+
+  it("invokes onTree for tree events", () => {
+    const onTree = vi.fn();
+    render(<Harness onTree={onTree} onChanged={() => {}} />);
+
+    emit({ type: "tree" });
+    expect(onTree).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onChanged with the changed path", () => {
+    const onChanged = vi.fn();
+    render(<Harness onTree={() => {}} onChanged={onChanged} />);
+
+    emit({ type: "changed", path: "/a.puml" });
+    expect(onChanged).toHaveBeenCalledWith("/a.puml");
+  });
+
+  it("ignores hello events", () => {
+    const onTree = vi.fn();
+    const onChanged = vi.fn();
+    render(<Harness onTree={onTree} onChanged={onChanged} />);
+
+    emit({ type: "hello" });
+    expect(onTree).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it("does not resubscribe when handler identities change between renders", () => {
+    const onTreeA = vi.fn();
+    const onTreeB = vi.fn();
+    render(<Harness onTree={onTreeA} onChanged={() => {}} />);
+    render(<Harness onTree={onTreeB} onChanged={() => {}} />);
+
+    expect(mockedSubscribe).toHaveBeenCalledTimes(1);
+
+    emit({ type: "tree" });
+    expect(onTreeA).not.toHaveBeenCalled();
+    expect(onTreeB).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the latest onChanged after re-render", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    render(<Harness onTree={() => {}} onChanged={first} />);
+    render(<Harness onTree={() => {}} onChanged={second} />);
+
+    emit({ type: "changed", path: "/x.puml" });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith("/x.puml");
+  });
+
+  it("sees updated closure values through the ref (active path swap)", () => {
+    const ctx = RebindHarness as unknown as {
+      setActive: (p: string | null) => void;
+      changedCount?: number;
+    };
+    render(<RebindHarness />);
+
+    emit({ type: "changed", path: "/a.puml" });
+    expect(ctx.changedCount).toBe(1);
+
+    act(() => ctx.setActive("/b.puml"));
+
+    emit({ type: "changed", path: "/a.puml" });
+    expect(ctx.changedCount).toBe(1);
+
+    emit({ type: "changed", path: "/b.puml" });
+    expect(ctx.changedCount).toBe(2);
+  });
+
+  it("invokes the cleanup returned by subscribe on unmount", () => {
+    render(<Harness onTree={() => {}} onChanged={() => {}} />);
+    expect(subscriptions[0]!.cleanup).not.toHaveBeenCalled();
+
+    render(<div />);
+    expect(subscriptions[0]!.cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/internal/frontend/src/hooks/useServerEvents.ts
+++ b/internal/frontend/src/hooks/useServerEvents.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+import { subscribe } from "../api/events";
+
+export interface ServerEventHandlers {
+  onTree: () => void;
+  onChanged: (path: string) => void;
+}
+
+export function useServerEvents(handlers: ServerEventHandlers): void {
+  // The SSE subscription opens once and must survive handler-identity churn,
+  // so route every event through a ref that always points at the latest one.
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    return subscribe((ev) => {
+      if (ev.type === "changed") {
+        handlersRef.current.onChanged(ev.path);
+      } else if (ev.type === "tree") {
+        handlersRef.current.onTree();
+      }
+    });
+  }, []);
+}

--- a/internal/frontend/src/test/flush.ts
+++ b/internal/frontend/src/test/flush.ts
@@ -1,0 +1,9 @@
+import { act } from "react";
+
+export async function flush(ticks = 1): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < ticks; i++) {
+      await Promise.resolve();
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Closes #34. Extracts the three `useEffect` blocks in `App.tsx` into custom hooks, one per responsibility:

- **`useFileList`** — owns `files` / `active` / reload key; preserves the active path across reloads when it still exists, falls back to the first file otherwise.
- **`useActiveRender(active)`** — owns `source` / `render` / reload key, plus the `renderSeq` cancel token that protects against rapid-file-switch races.
- **`useServerEvents({ onTree, onChanged })`** — opens the SSE subscription once and routes each event through a `handlersRef` so callers can pass fresh closures without resubscribing. This subsumes the old `activeRef` trick.

`App.tsx` shrinks from ~80 lines of mixed state/refs/effects to a 3-hook composition that mirrors the proposal in the issue:

```ts
const { files, active, setActive, reload: reloadFiles } = useFileList();
const { source, render, reload: reloadActive } = useActiveRender(active);
useServerEvents({
  onTree: reloadFiles,
  onChanged: (path) => { if (path === active) reloadActive(); },
});
```

Behaviour is preserved: same SSE subscription lifetime (open once, close on unmount), same cancel-token semantics for stale fetches, same "preserve `active` if it still exists in the new file list" rule.

## Test plan

- [x] `make test-frontend` — 158 tests pass (25 new across the three hook suites)
- [x] `make lint` (frontend) — 0 warnings / 0 errors; oxfmt clean
- [x] `make lint-backend` — clean (after `pnpm build` populates `internal/static/dist`)
- [x] `tsc --noEmit` — clean
- [x] `pnpm build` — frontend bundle builds successfully
- [ ] `make e2e` — not run in this environment (Playwright browsers not installed); the refactor preserves observable behaviour and is covered by unit tests for each extracted hook (file-list reload, stale-fetch cancellation, SSE handler-identity stability, cleanup on unmount, etc.)

### New unit coverage

- `useFileList.test.tsx` — initial load, empty list, `setActive`, preserve-active-across-reload, fallback when active vanishes, clear-on-empty, reload count.
- `useActiveRender.test.tsx` — idle/loading/ok/error transitions, return-to-idle when active becomes null, **stale fetch from a rapid switch is discarded**, reload re-fetches, non-`Error` throwables get stringified.
- `useServerEvents.test.tsx` — subscribes once, dispatches tree/changed, ignores hello, does NOT resubscribe on handler-identity change, calls the latest closure (replaces the `activeRef` trick), cleanup runs on unmount.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8wXacDqGwgnKQdfnyPWLQ)_