### PR TITLE
fix(frontend): make plantuml.js dimension-limit patch resilient to minifier changes

### DIFF
--- a/internal/frontend/scripts/fetch-plantuml-core.mjs
+++ b/internal/frontend/scripts/fetch-plantuml-core.mjs
@@ -29,10 +29,14 @@ const REQUIRED_FILES = ["plantuml.js", "viz-global.js"];
 // sequence diagrams (observed max: ~56 000px) while still bounding pathological
 // inputs. SVG is vector, so coordinate-system size has no meaningful effect on
 // memory or rendering performance.
-const PLANTUML_PATCHES = [
-  { from: "p<=4096.0", to: "p<=65536.0" },
-  { from: "q<=4096.0", to: "q<=65536.0" },
-];
+//
+// The limit appears as two `4096.0` literals — one per axis — inside the
+// dimension guard (currently minified to `if(!(p>4096.0)){...if(!(q>4096.0))`).
+// We match the bare `4096.0` constant rather than the surrounding expression so
+// the patch survives the minifier renaming variables or flipping the comparison
+// operator (both have happened across upstream snapshot builds). The constant is
+// unique to this guard, so replacing every occurrence is safe.
+const PLANTUML_PATCHES = [{ from: "4096.0", to: "65536.0" }];
 
 function patchPlantumlJs(filePath) {
   let src = readFileSync(filePath, "utf8");


### PR DESCRIPTION
## Summary

CI was failing across the **Backend** and **E2E** jobs because the frontend build step (`make generate` / `make build` → `pnpm run build` → `fetch-plantuml-core.mjs`) bailed out:

```
plantuml.js patch failed: expected "p<=4096.0" or "p<=65536.0" not found.
The upstream TeaVM build may have changed. Update PLANTUML_PATCHES in fetch-plantuml-core.mjs.
```

The upstream `plantuml/plantuml` TeaVM snapshot build changed how it minifies the dimension guard. It now emits:

```js
if(!(p>4096.0)){ ... if(!(q>4096.0)){ ...
```

instead of the previous `p<=4096.0` / `q<=4096.0` form. The comparison operator was flipped (`<=` → `>`), so the literal `from` patterns in `PLANTUML_PATCHES` no longer matched and the script exited 1.

## Fix

Match the bare `4096.0` constant instead of the surrounding expression. The constant appears exactly twice — once per axis — and is unique to the dimension guard, so the patch now survives the minifier renaming variables **or** flipping the comparison operator across snapshot builds. Replacing every occurrence is safe.

## Test plan

- [x] `pnpm run build` (fresh download + patch) succeeds — `plantuml.js: raised dimension limit from 4096 to 65536px`
- [x] Verified patched file: `65536.0` present 2×, `4096.0` no longer present
- [x] `make build` produces the binary (Go embed picks up `dist/`)
- [x] `pnpm lint` / `pnpm fmt:check` clean
- [x] `pnpm test:unit` (159) and `pnpm test:integration` (30) pass
- [x] `go vet ./...` clean, `internal/server` tests pass

The dimension limit is exercised by the renderer; the build itself is the gate that was broken, and it now completes end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeNja3ojgazKTJxYLvvpRT)_