### PR TITLE
ci(e2e): use bundled Chromium instead of branded Chrome channel

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -10,7 +10,7 @@ The suite lives in `internal/frontend/tests/e2e/` and is driven by `make e2e`, w
 1. Runs `make build` — `go generate ./...` (which builds the embedded SPA via `pnpm run build`) then `go build -trimpath -o pumlv .`.
 2. Runs `cd internal/frontend && pnpm test:e2e` (i.e. `playwright test`). Playwright's `webServer` spec spawns the freshly-built `./pumlv` on `127.0.0.1:8766` against `../../examples` and tears it down after the run.
 
-The configured project is `chromium` only, and it launches with `channel: "chrome"`.
+The configured project is `chromium` only, and it launches Playwright's bundled Chromium (no branded `channel`), so the browser comes from `playwright install chromium` rather than a system Google Chrome.
 
 ## Run it
 
@@ -22,7 +22,7 @@ That is the whole happy path. Run from the repo root.
 
 ## Recovering from failures
 
-- **`Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`** — Playwright is set to `channel: "chrome"` and Chrome isn't installed. Try `cd internal/frontend && pnpm exec playwright install chrome`. If the sandbox blocks the download (e.g. apt mirrors return 403), find a preinstalled chromium under `/opt/pw-browsers/<version>/chrome-linux/chrome` and symlink it to the path Playwright is checking: `mkdir -p /opt/google/chrome && ln -sf /opt/pw-browsers/<version>/chrome-linux/chrome /opt/google/chrome/chrome`, then re-run `make e2e`. Note that `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` does **not** work here — it only overrides `channel: "chromium"`, not `channel: "chrome"`. Do **not** edit `playwright.config.ts` to bake in a sandbox-local path.
+- **`Executable doesn't exist at .../chrome-linux/chrome`** — the bundled Chromium isn't installed. Run `cd internal/frontend && pnpm exec playwright install chromium chromium-headless-shell`. In sandboxes the browsers are usually preinstalled under `/opt/pw-browsers` (with `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers` already set), so Playwright finds them without a download. Do **not** edit `playwright.config.ts` to bake in a sandbox-local path.
 
 - **Server didn't come up within 30 s** — the binary is missing or stale. Confirm `./pumlv --no-open --port 8766 ./examples` boots by hand. If `make build` fails earlier with `pattern all:dist: no matching files found` from `internal/static/embed.go`, the frontend bundle wasn't produced — re-run `make build` from a clean tree (the `go:generate` directive runs `pnpm install && pnpm run build`).
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
 
       - uses: ./.github/actions/setup-playwright
         with:
-          browsers: chrome
+          browsers: chromium chromium-headless-shell
 
       - name: E2E tests
         run: make e2e

--- a/internal/frontend/playwright.config.ts
+++ b/internal/frontend/playwright.config.ts
@@ -14,7 +14,6 @@ export default defineConfig({
   use: {
     baseURL: `http://127.0.0.1:${PORT}`,
     trace: "retain-on-failure",
-    channel: "chrome",
     launchOptions: {
       args: ["--disable-dev-shm-usage"],
     },

--- a/internal/frontend/scripts/screenshots.mjs
+++ b/internal/frontend/scripts/screenshots.mjs
@@ -76,7 +76,7 @@ async function waitForServer(url, timeoutMs = 30_000) {
 const baseURL = `http://127.0.0.1:${PORT}`;
 await waitForServer(`${baseURL}/api/files`);
 
-const browser = await chromium.launch({ channel: "chrome" });
+const browser = await chromium.launch();
 try {
   const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
   const page = await ctx.newPage();


### PR DESCRIPTION
## 概要

CI の `E2E (macos-15)` ジョブが全 PR で恒常的に失敗していた問題 (#82) を解消します。

## 原因

`internal/frontend/playwright.config.ts` が `use.channel: "chrome"`（branded Google Chrome）を指定していたため、CI は `playwright install --with-deps chrome` を実行していました。macos-15 ランナーでは Google Chrome の `.dmg` 取得が失敗（138 バイトのエラー応答 → `hdiutil attach` がマウント失敗）し、**テストが 1 件も走る前にブラウザインストール段階でジョブが落ちて**いました。Linux では Chrome のインストールが通るため `E2E (ubuntu-24.04)` は成功しており、macOS 固有の環境問題でした。

## 変更内容

- **`playwright.config.ts`**: `channel: "chrome"` を削除。`devices["Desktop Chrome"]` は `defaultBrowserType: "chromium"` のみで channel を持たないため、これだけで Playwright 同梱の bundled Chromium が使われるようになります。
- **`.github/workflows/ci.yml`**: e2e ジョブの `setup-playwright` に渡すブラウザを `chrome` → `chromium chromium-headless-shell` に変更（`frontend` ジョブと同じ指定）。Google の dmg 配布への依存がなくなります。
- **`scripts/screenshots.mjs`**: `chromium.launch({ channel: "chrome" })` → `chromium.launch()`。`make screenshot` でも同じ macOS 問題を踏まないように統一。
- **`.claude/skills/e2e/SKILL.md`**: 旧挙動（`channel: "chrome"`）前提の記述を bundled Chromium 前提に更新。

## Test plan

- [x] `make build` 成功
- [x] `pnpm test:e2e`（bundled Chromium / Linux）で全 3 spec パス
  - `renders the initially selected file as an SVG data URL`
  - `re-renders when another file is selected`
  - `collapses and re-expands a directory from its toggle header`
- [x] リポジトリ全体に branded `channel: "chrome"` / `browsers: chrome` の残存がないことを確認
- [ ] macos-15 ランナーでの E2E グリーン化（この環境では macOS を実行できないため、CI 上で確認）

Closes #82

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDmKsjFYtDK5Jn4dRVxTjQ)_