### PR TITLE
build(deps): bump react-zoom-pan-pinch from 3.7.0 to 4.0.3

### DIFF
--- a/internal/frontend/package.json
+++ b/internal/frontend/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-zoom-pan-pinch": "^3.7.0",
+    "react-zoom-pan-pinch": "^4.0.3",
     "shiki": "^4.1.0"
   },
   "devDependencies": {

--- a/internal/frontend/pnpm-lock.yaml
+++ b/internal/frontend/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^19.1.0
         version: 19.2.6(react@19.2.6)
       react-zoom-pan-pinch:
-        specifier: ^3.7.0
-        version: 3.7.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^4.0.3
+        version: 4.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       shiki:
         specifier: ^4.1.0
         version: 4.1.0
@@ -2067,8 +2067,8 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-zoom-pan-pinch@3.7.0:
-    resolution: {integrity: sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==}
+  react-zoom-pan-pinch@4.0.3:
+    resolution: {integrity: sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==}
     engines: {node: '>=8', npm: '>=5'}
     peerDependencies:
       react: '*'
@@ -4216,7 +4216,7 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-zoom-pan-pinch@3.7.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-zoom-pan-pinch@4.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)

--- a/internal/frontend/src/components/preview/use-keyboard-pan.test.tsx
+++ b/internal/frontend/src/components/preview/use-keyboard-pan.test.tsx
@@ -37,24 +37,24 @@ describe("useKeyboardPan", () => {
   ])("$key shifts the transform by ($dx, $dy)", ({ key, dx, dy }) => {
     const { result } = mount();
     pressKey(key);
-    expect(result.current.transformState.positionX).toBe(dx);
-    expect(result.current.transformState.positionY).toBe(dy);
-    expect(result.current.transformState.scale).toBe(1);
+    expect(result.current.state.positionX).toBe(dx);
+    expect(result.current.state.positionY).toBe(dy);
+    expect(result.current.state.scale).toBe(1);
   });
 
   it("uses a larger step when Shift is held", () => {
     const { result } = mount();
     pressKey("ArrowRight", { shiftKey: true });
-    expect(result.current.transformState.positionX).toBe(-200);
-    expect(result.current.transformState.positionY).toBe(0);
+    expect(result.current.state.positionX).toBe(-200);
+    expect(result.current.state.positionY).toBe(0);
   });
 
   it("ignores non-arrow keys", () => {
     const { result } = mount();
     pressKey("a");
     pressKey("Enter");
-    expect(result.current.transformState.positionX).toBe(0);
-    expect(result.current.transformState.positionY).toBe(0);
+    expect(result.current.state.positionX).toBe(0);
+    expect(result.current.state.positionY).toBe(0);
   });
 
   it.each(["INPUT", "TEXTAREA"])("ignores arrows while typing in a %s", (tagName) => {
@@ -66,8 +66,8 @@ describe("useKeyboardPan", () => {
       act(() => {
         editable.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
       });
-      expect(result.current.transformState.positionX).toBe(0);
-      expect(result.current.transformState.positionY).toBe(0);
+      expect(result.current.state.positionX).toBe(0);
+      expect(result.current.state.positionY).toBe(0);
     } finally {
       editable.remove();
     }
@@ -76,9 +76,9 @@ describe("useKeyboardPan", () => {
   it("reads the latest position on each keypress", () => {
     const { result } = mount();
     pressKey("ArrowRight");
-    expect(result.current.transformState.positionX).toBe(-50);
+    expect(result.current.state.positionX).toBe(-50);
     pressKey("ArrowRight");
-    expect(result.current.transformState.positionX).toBe(-100);
+    expect(result.current.state.positionX).toBe(-100);
   });
 
   it("removes the listener on unmount", () => {
@@ -86,6 +86,6 @@ describe("useKeyboardPan", () => {
     const ctx = result.current;
     unmount();
     pressKey("ArrowRight");
-    expect(ctx.transformState.positionX).toBe(0);
+    expect(ctx.state.positionX).toBe(0);
   });
 });

--- a/internal/frontend/src/components/preview/use-keyboard-pan.ts
+++ b/internal/frontend/src/components/preview/use-keyboard-pan.ts
@@ -39,8 +39,8 @@ export function useKeyboardPan(): void {
           return;
       }
       e.preventDefault();
-      const { positionX, positionY, scale } = ctx.transformState;
-      ctx.setTransformState(scale, positionX + dx, positionY + dy);
+      const { positionX, positionY, scale } = ctx.state;
+      ctx.setState(scale, positionX + dx, positionY + dy);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);


### PR DESCRIPTION
## 概要

react-zoom-pan-pinch の破壊的メジャー 3.7.0 → 4.0.3。v4 では `useTransformContext()` が返すインスタンスの内部 API 名が変わり、`useKeyboardPan` が依存していた箇所が壊れていました（#76 の CI 失敗の原因）。

## v4 の変更点と対応

`useKeyboardPan` が使う transform-context インスタンス API:

- `ctx.transformState` → **`ctx.state`**
- `ctx.setTransformState(scale, x, y)` → **`ctx.setState(scale, x, y)`**

state の形（`scale` / `positionX` / `positionY`）は不変。`use-keyboard-pan.ts` とそのテストを新 API に追従。

その他に使用しているライブラリ API（`useControls` / `useTransformComponent` / `MiniMap` / `TransformWrapper` / `TransformComponent`）は v4 でも型・挙動互換で、`tsc --noEmit` も含め変更不要でした。

## Test plan

- [x] `tsc --noEmit` + `vite build` 成功
- [x] `pnpm lint`（oxlint）/ `pnpm fmt:check`（oxfmt）クリーン
- [x] `pnpm test:unit` 159 件パス（keyboard-pan の単体含む）
- [x] `pnpm test:integration` 30 件パス
- [x] `pnpm test:e2e` 3 件パス（bundled Chromium / Linux）
- [x] CI（E2E 含む）で確認

Supersedes #76

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDmKsjFYtDK5Jn4dRVxTjQ)_