### PR TITLE
ci(tagpr): serialize runs to avoid concurrent git-data API 401

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -14,11 +14,7 @@ jobs:
   tagpr:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    # Without this, a burst of pushes to main (e.g. Dependabot auto-merges)
-    # starts multiple tagpr jobs that race to update the same release branch/PR
-    # via the git data API; the losers fail with "git/trees: 401 Requires
-    # authentication". cancel-in-progress: false never aborts a run that may
-    # already be producing a tag/release.
+    # Serialize runs so concurrent pushes don't race the git data API (401).
     concurrency:
       group: tagpr-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -14,6 +14,15 @@ jobs:
   tagpr:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # Serialize tagpr runs per branch. Rapid pushes to main (e.g. a burst of
+    # Dependabot auto-merges) would otherwise start multiple tagpr jobs that
+    # race to update the same release branch/PR via the git data API, and the
+    # losers fail with "git/trees: 401 Requires authentication". Queueing keeps
+    # only the latest pending run; cancel-in-progress: false never aborts a run
+    # that may already be producing a tag/release.
+    concurrency:
+      group: tagpr-${{ github.ref }}
+      cancel-in-progress: false
     outputs:
       tag: ${{ steps.tagpr.outputs.tag }}
     steps:

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -14,12 +14,11 @@ jobs:
   tagpr:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    # Serialize tagpr runs per branch. Rapid pushes to main (e.g. a burst of
-    # Dependabot auto-merges) would otherwise start multiple tagpr jobs that
-    # race to update the same release branch/PR via the git data API, and the
-    # losers fail with "git/trees: 401 Requires authentication". Queueing keeps
-    # only the latest pending run; cancel-in-progress: false never aborts a run
-    # that may already be producing a tag/release.
+    # Without this, a burst of pushes to main (e.g. Dependabot auto-merges)
+    # starts multiple tagpr jobs that race to update the same release branch/PR
+    # via the git data API; the losers fail with "git/trees: 401 Requires
+    # authentication". cancel-in-progress: false never aborts a run that may
+    # already be producing a tag/release.
     concurrency:
       group: tagpr-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
## What

The `tagpr` workflow on `main` has been failing intermittently with:

```
POST https://api.github.com/repos/rin2yh/pumlv/git/trees: 401 Requires authentication
```

This adds a per-branch `concurrency` group to the `tagpr` job so the runs serialize.

## Root cause

The failures correlate exactly with **overlapping `tagpr` runs**, not with a real token problem. Looking at the `tagpr` run history on `main`:

| time (06-10) | sha | result |
|---|---|---|
| 15:17:57 | `03d3b5e4` | ✅ success |
| 15:18:15 | `ba3562f1` | ❌ failure |
| 15:18:44 | `8359e712` | ❌ failure |
| 15:27:27 | `6b3b6468` | ✅ success (isolated) |

The two failures land **18s and 29s** after a success — a burst of Dependabot auto-merges pushed several commits to `main` back-to-back, starting multiple `tagpr` jobs simultaneously. They all tried to update the same `tagpr-from-vX` release branch / PR #92 through the git data API; the first won, the overlapping ones got a spurious `401` and turned `main` red. On 06-05, where pushes were spaced out, every `tagpr` run passed.

`tagpr` has no concurrency control, so nothing prevented these races.

## Fix

Scope a `concurrency` group to the `tagpr` job:

```yaml
concurrency:
  group: tagpr-${{ github.ref }}
  cancel-in-progress: false
```

- Serializes `tagpr` runs per branch, eliminating the race.
- `cancel-in-progress: false` never aborts a run that may already be producing a tag/release; GitHub keeps only the latest pending run, so a Dependabot burst collapses to "current + latest" instead of N racing jobs.
- The `release` job is deliberately left unscoped so a release is never cancelled mid-flight.

## Test plan

- [x] `tagpr.yml` parses as valid YAML.
- [ ] Next push to `main` runs a single, serialized `tagpr` job that completes without the 401. *(Only observable post-merge on `main`; cannot be exercised from a feature branch.)*

## Notes

I could not retroactively turn the current red run on `main` (`cc8ec790`) green — re-running workflow jobs is not permitted for this integration token (`403 Resource not accessible by integration`). The next push to `main` after merging this will exercise the fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qr4n3yHCx4Rg8HHG3BNcLk)_