### PR TITLE
Ignore .claude/worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ go.work.sum
 /internal/frontend/test-results/
 /internal/frontend/playwright-report/
 /internal/frontend/.playwright/
+
+# Claude Code agent worktrees
+/.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `/.claude/worktrees/` to `.gitignore`
- Agent-driven parallel PR triage creates temporary git worktrees under `.claude/worktrees/` for isolation; these are ephemeral working copies and shouldn't be tracked or flagged as untracked changes.

## Test plan
- [x] `git status` shows the worktrees directory no longer appears as untracked after the change
- [ ] `make lint` / `make test` — not run; this is a non-code `.gitignore`-only change with no build/test impact


---
_Generated by [Claude Code](https://claude.ai/code/session_01NtDtCdK1bKExoUFFAcFWmH)_