### PR TITLE
ci: restore release generation and verify generated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-generated-files:
+    name: Check generated files
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - uses: ./.github/actions/setup-frontend
+
+      - name: Generate
+        run: make generate
+
+      - name: Check generated files are up to date
+        run: git diff --exit-code
+
   backend:
     name: Backend
     runs-on: ubuntu-24.04

--- a/credits/frontend.txt
+++ b/credits/frontend.txt
@@ -879,7 +879,7 @@ SOFTWARE.
 ================================================================
 
 react-zoom-pan-pinch
-https://github.com/prc5/react-zoom-pan-pinch#readme
+https://github.com/BetterTyped/react-zoom-pan-pinch#readme
 ----------------------------------------------------------------
 MIT License
 


### PR DESCRIPTION
## Summary

- regenerate `credits/frontend.txt` from the latest `main` so the next tagpr release starts from committed generated output
- add a PR-only `check-generated-files` job that runs `make generate` and fails on uncommitted generated changes
- leave the release workflow, GoReleaser configuration, and tagpr configuration unchanged

v0.3.8 remains skipped; this PR does not retag it or bypass GoReleaser validation.

## Verification

- `make generate`
- `git diff --exit-code` after regeneration
- `make lint-frontend`
- `make lint-backend`
- `make test-frontend-unit` (159 tests)
- `make test-backend`
